### PR TITLE
workspace death spiral in content editor

### DIFF
--- a/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
+++ b/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
@@ -48,6 +48,12 @@ class ContentEditorAgent extends BaseCodingAgent
             '- Build output goes to dist/ or build/ (generated, do not edit directly)',
             '- README.md contains project documentation and instructions',
             '',
+            'PATH RULES (critical):',
+            '- The working folder path is given in the user\'s message. Use it for ALL path-based tools (get_folder_content, get_file_content, get_file_lines, replace_in_file, apply_diff_to_file, run_quality_checks, run_tests, run_build).',
+            '- "Workspace root" and "working folder" are the same. Both mean the path from the user\'s message.',
+            '- Never use /workspace or any path not under the working folder unless the user explicitly gave you that path.',
+            '- If a tool returns "Directory does not exist" or "File does not exist", the path you used is wrong. Do not retry the same path. Re-read the user\'s message for the correct working folder and use paths under it.',
+            '',
             'EFFICIENT FILE READING:',
             '- Use get_file_info first to check file size before reading',
             '- For large files (>100 lines), use search_in_file to find relevant sections',
@@ -81,7 +87,7 @@ class ContentEditorAgent extends BaseCodingAgent
     protected function getStepInstructions(): array
     {
         return [
-            '1. EXPLORE: List the workspace root folder to understand its structure.',
+            '1. EXPLORE: List the working folder (the path from the user\'s message) to understand its structure.',
             '2. UNDERSTAND: Read package.json and README.md to learn about the project.',
             '3. INVESTIGATE: Use get_file_info + search_in_file to efficiently explore files.',
             '4. PLAN: Understand what files need to be created or modified.',

--- a/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
+++ b/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
@@ -25,6 +25,8 @@ final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
      */
     public function streamEdit(string $workspacePath, string $instruction): Generator
     {
+        // Always include the working folder so the agent uses it for all path-based tools.
+        // Omitting it led to the agent guessing /workspace and retrying get_folder_content in a loop.
         $prompt = sprintf(
             'The working folder is: %s' . "\n\n" . 'Please perform the following task: %s',
             $workspacePath,

--- a/src/WorkspaceTooling/Facade/WorkspaceToolingFacade.php
+++ b/src/WorkspaceTooling/Facade/WorkspaceToolingFacade.php
@@ -46,4 +46,13 @@ final class WorkspaceToolingFacade extends BaseWorkspaceToolingFacade implements
             'mise exec -- npm run build'
         );
     }
+
+    public function applyV4aDiffToFile(string $pathToFile, string $v4aDiff): string
+    {
+        $modifiedContent = $this->textOperationsService->applyDiffToFile($pathToFile, $v4aDiff);
+        $this->fileOperationsService->writeFileContent($pathToFile, $modifiedContent);
+        $lineCount = substr_count($modifiedContent, "\n") + 1;
+
+        return "Applied. File now has {$lineCount} lines.";
+    }
 }

--- a/tests/Unit/LlmContentEditor/ContentEditorAgentTest.php
+++ b/tests/Unit/LlmContentEditor/ContentEditorAgentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\LlmContentEditor;
+
+use App\LlmContentEditor\Domain\Agent\ContentEditorAgent;
+use App\WorkspaceTooling\Facade\WorkspaceToolingServiceInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class ContentEditorAgentTest extends TestCase
+{
+    public function testGetBackgroundInstructionsContainsPathRules(): void
+    {
+        $agent = new ContentEditorAgent($this->createMockWorkspaceTooling());
+        $ref   = new ReflectionMethod(ContentEditorAgent::class, 'getBackgroundInstructions');
+        $ref->setAccessible(true);
+
+        /** @var list<string> $instructions */
+        $instructions = $ref->invoke($agent);
+        $text         = implode("\n", $instructions);
+
+        self::assertStringContainsString('PATH RULES (critical)', $text);
+        self::assertStringContainsString('Never use /workspace', $text);
+        self::assertStringContainsString('Directory does not exist', $text);
+        self::assertStringContainsString('Do not retry the same path', $text);
+    }
+
+    public function testGetStepInstructionsExploreStepRefersToWorkingFolderFromUserMessage(): void
+    {
+        $agent = new ContentEditorAgent($this->createMockWorkspaceTooling());
+        $ref   = new ReflectionMethod(ContentEditorAgent::class, 'getStepInstructions');
+        $ref->setAccessible(true);
+
+        /** @var list<string> $steps */
+        $steps = $ref->invoke($agent);
+
+        self::assertNotEmpty($steps);
+        $exploreStep = $steps[0];
+        self::assertStringContainsString('working folder', $exploreStep);
+        self::assertStringContainsString("path from the user's message", $exploreStep);
+        self::assertStringNotContainsString('workspace root folder', $exploreStep);
+    }
+
+    private function createMockWorkspaceTooling(): WorkspaceToolingServiceInterface
+    {
+        return $this->createMock(WorkspaceToolingServiceInterface::class);
+    }
+}

--- a/tests/Unit/WorkspaceTooling/WorkspaceToolingFacadeTest.php
+++ b/tests/Unit/WorkspaceTooling/WorkspaceToolingFacadeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\WorkspaceTooling;
+
+use App\WorkspaceTooling\Facade\WorkspaceToolingFacade;
+use EtfsCodingAgent\Service\FileOperationsService;
+use EtfsCodingAgent\Service\ShellOperationsServiceInterface;
+use EtfsCodingAgent\Service\TextOperationsService;
+use PHPUnit\Framework\TestCase;
+
+final class WorkspaceToolingFacadeTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/wstest_' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testApplyV4aDiffToFileReturnsShortSummaryWithCorrectLineCount(): void
+    {
+        $path = $this->tempDir . '/f.txt';
+        file_put_contents($path, "line 1\nline 2\nline 3");
+        $diff = " line 1\n-line 2\n+line 2 updated\n line 3";
+
+        $facade = $this->createFacade();
+        $result = $facade->applyV4aDiffToFile($path, $diff);
+
+        self::assertSame('Applied. File now has 3 lines.', $result);
+    }
+
+    public function testApplyV4aDiffToFileWritesModifiedContentToFile(): void
+    {
+        $path = $this->tempDir . '/f.txt';
+        file_put_contents($path, "line 1\nline 2\nline 3");
+        $diff = " line 1\n-line 2\n+line 2 updated\n line 3";
+
+        $facade = $this->createFacade();
+        $facade->applyV4aDiffToFile($path, $diff);
+
+        self::assertSame("line 1\nline 2 updated\nline 3", file_get_contents($path));
+    }
+
+    public function testApplyV4aDiffToFileWithSingleLineContentReturnsOneLine(): void
+    {
+        $path = $this->tempDir . '/one.txt';
+        file_put_contents($path, 'single line');
+        $diff = ' single line';
+
+        $facade = $this->createFacade();
+        $result = $facade->applyV4aDiffToFile($path, $diff);
+
+        self::assertSame('Applied. File now has 1 lines.', $result);
+    }
+
+    private function createFacade(): WorkspaceToolingFacade
+    {
+        $fileOps  = new FileOperationsService();
+        $textOps  = new TextOperationsService($fileOps);
+        $shellOps = $this->createMock(ShellOperationsServiceInterface::class);
+
+        return new WorkspaceToolingFacade($fileOps, $textOps, $shellOps);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = scandir($dir);
+        if ($files === false) {
+            return;
+        }
+        foreach ($files as $file) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $file;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
In the sitebuilder webapp, the content editor tends to get into a "death spiral":

```
 Calling: apply_diff_to_file

    path: /var/www/var/tmp/workspaces/callven-corporate/src/yoga-studios.html
    diff: @@ - <blockquote class="hermes-testimonial-quote"> - „Seit wir Callv...

◀ Result: <!doctype html> <html lang="de" class="h-full"> <head> <meta charset="UTF-8" /> <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <title>Callven für Yoga-Studios –…
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_file_content

    path: /workspace/package.json

◀ Result: Error: File does not exist: /workspace/package.json
▶ Calling: get_file_content

    path: /workspace/README.md

◀ Result: Error: File does not exist: /workspace/README.md
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
▶ Calling: get_folder_content

    path: /workspace

◀ Result: Error: Directory does not exist: /workspace. Use create_directory to create it first.
```