### PR TITLE
Feature Request: Conversation Memory for AI Chat Editor

### DIFF
--- a/migrations/Version20260120120440.php
+++ b/migrations/Version20260120120440.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260120120440 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Conversation entity and link EditSession to it; drop workspace_path from edit_sessions.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->connection->executeStatement('CREATE TABLE conversations (id CHAR(36) NOT NULL, workspace_path VARCHAR(4096) NOT NULL, created_at DATETIME NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->connection->executeStatement('ALTER TABLE edit_sessions ADD conversation_id CHAR(36) DEFAULT NULL');
+
+        $rows = $this->connection->fetchAllAssociative('SELECT id, workspace_path, created_at FROM edit_sessions');
+        foreach ($rows as $row) {
+            $uuid = $this->connection->fetchOne('SELECT UUID()');
+            $this->connection->executeStatement(
+                'INSERT INTO conversations (id, workspace_path, created_at) VALUES (?, ?, ?)',
+                [$uuid, $row['workspace_path'], $row['created_at']]
+            );
+            $this->connection->executeStatement(
+                'UPDATE edit_sessions SET conversation_id = ? WHERE id = ?',
+                [$uuid, $row['id']]
+            );
+        }
+
+        $this->addSql('ALTER TABLE edit_sessions MODIFY conversation_id CHAR(36) NOT NULL');
+        $this->addSql('ALTER TABLE edit_sessions DROP workspace_path');
+        $this->addSql('ALTER TABLE edit_sessions ADD CONSTRAINT FK_B16E393A9AC0396 FOREIGN KEY (conversation_id) REFERENCES conversations (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_B16E393A9AC0396 ON edit_sessions (conversation_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE conversations');
+        $this->addSql('ALTER TABLE edit_sessions DROP FOREIGN KEY FK_B16E393A9AC0396');
+        $this->addSql('DROP INDEX IDX_B16E393A9AC0396 ON edit_sessions');
+        $this->addSql('ALTER TABLE edit_sessions ADD workspace_path VARCHAR(4096) NOT NULL, DROP conversation_id');
+    }
+}

--- a/src/ChatBasedContentEditor/Domain/Entity/Conversation.php
+++ b/src/ChatBasedContentEditor/Domain/Entity/Conversation.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ChatBasedContentEditor\Domain\Entity;
+
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use EnterpriseToolingForSymfony\SharedBundle\DateAndTime\Service\DateAndTimeService;
+use Exception;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'conversations')]
+class Conversation
+{
+    /**
+     * @throws Exception
+     */
+    public function __construct(string $workspacePath)
+    {
+        $this->workspacePath = $workspacePath;
+        $this->createdAt     = DateAndTimeService::getDateTimeImmutable();
+        $this->editSessions  = new ArrayCollection();
+    }
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[ORM\Column(
+        type: Types::GUID,
+        unique: true
+    )]
+    private ?string $id = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    #[ORM\Column(
+        type: Types::STRING,
+        length: 4096,
+        nullable: false
+    )]
+    private readonly string $workspacePath;
+
+    public function getWorkspacePath(): string
+    {
+        return $this->workspacePath;
+    }
+
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        nullable: false
+    )]
+    private readonly DateTimeImmutable $createdAt;
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @var Collection<int, EditSession>
+     */
+    #[ORM\OneToMany(
+        targetEntity: EditSession::class,
+        mappedBy: 'conversation',
+        cascade: ['persist', 'remove'],
+        orphanRemoval: true
+    )]
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
+    private Collection $editSessions;
+
+    /**
+     * @return Collection<int, EditSession>
+     */
+    public function getEditSessions(): Collection
+    {
+        return $this->editSessions;
+    }
+}

--- a/src/ChatBasedContentEditor/Domain/Entity/EditSession.php
+++ b/src/ChatBasedContentEditor/Domain/Entity/EditSession.php
@@ -22,14 +22,14 @@ class EditSession
      * @throws Exception
      */
     public function __construct(
-        string $workspacePath,
-        string $instruction
+        Conversation $conversation,
+        string       $instruction
     ) {
-        $this->workspacePath = $workspacePath;
-        $this->instruction   = $instruction;
-        $this->status        = EditSessionStatus::Pending;
-        $this->createdAt     = DateAndTimeService::getDateTimeImmutable();
-        $this->chunks        = new ArrayCollection();
+        $this->conversation = $conversation;
+        $this->instruction  = $instruction;
+        $this->status       = EditSessionStatus::Pending;
+        $this->createdAt    = DateAndTimeService::getDateTimeImmutable();
+        $this->chunks       = new ArrayCollection();
     }
 
     #[ORM\Id]
@@ -46,16 +46,19 @@ class EditSession
         return $this->id;
     }
 
-    #[ORM\Column(
-        type: Types::STRING,
-        length: 4096,
-        nullable: false
+    #[ORM\ManyToOne(
+        targetEntity: Conversation::class,
+        inversedBy: 'editSessions'
     )]
-    private readonly string $workspacePath;
+    #[ORM\JoinColumn(
+        nullable: false,
+        onDelete: 'CASCADE'
+    )]
+    private readonly Conversation $conversation;
 
     public function getWorkspacePath(): string
     {
-        return $this->workspacePath;
+        return $this->conversation->getWorkspacePath();
     }
 
     #[ORM\Column(

--- a/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
+++ b/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
@@ -7,15 +7,34 @@
          {{ stimulus_controller('chat-based-content-editor', {
              runUrl: runUrl,
              pollUrlTemplate: pollUrlTemplate,
-             workspacePath: defaultWorkspacePath|default('')
+             conversationId: conversation.id
          }) }}>
-        <h1 class="text-2xl font-semibold text-dark-900 dark:text-dark-100">Chat-based content editor</h1>
-        <p class="text-dark-600 dark:text-dark-400">Give instructions in natural language; the AI will edit files in the workspace and show what it does step by step.</p>
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-dark-900 dark:text-dark-100">Chat-based content editor</h1>
+                <p class="text-dark-600 dark:text-dark-400 mt-1">Give instructions in natural language; the AI will edit files in the workspace and show what it does step by step.</p>
+            </div>
+            <a href="{{ path('chat_based_content_editor.presentation.new') }}"
+               class="px-3 py-1.5 rounded-md border border-dark-300 dark:border-dark-600 text-dark-700 dark:text-dark-300 text-sm font-medium hover:bg-dark-100 dark:hover:bg-dark-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900">
+                New Conversation
+            </a>
+        </div>
 
         <div class="relative">
             <div {{ stimulus_target('chat-based-content-editor', 'messages') }}
                  class="rounded-lg border border-dark-200 dark:border-dark-700 bg-white dark:bg-dark-800 p-4 min-h-[320px] max-h-[500px] overflow-y-auto space-y-4">
-                <p class="text-dark-500 dark:text-dark-400 text-sm">Messages will appear here. Enter an instruction below and submit.</p>
+                {% if turns is empty %}
+                    <p class="text-dark-500 dark:text-dark-400 text-sm">Messages will appear here. Enter an instruction below and submit.</p>
+                {% else %}
+                    {% for turn in turns %}
+                        <div class="flex justify-end">
+                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-primary-100 dark:bg-primary-900/30 text-dark-900 dark:text-dark-100 text-sm">{{ turn.instruction }}</div>
+                        </div>
+                        <div class="flex justify-start">
+                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-dark-100 dark:bg-dark-700/50 text-dark-800 dark:text-dark-200 text-sm whitespace-pre-wrap {{ turn.status == 'failed' ? 'border-l-2 border-red-500 pl-2' : '' }}">{{ turn.response ?: '(No response)' }}</div>
+                        </div>
+                    {% endfor %}
+                {% endif %}
             </div>
             <div class="absolute bottom-2 right-2">
                 <label class="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-dark-100/80 dark:bg-dark-700/80 backdrop-blur-sm text-xs text-dark-600 dark:text-dark-300 cursor-pointer select-none">
@@ -33,18 +52,9 @@
               class="space-y-4">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('chat_based_content_editor_run') }}">
             <div>
-                <label for="workspace_path" class="block text-sm font-medium text-dark-700 dark:text-dark-300 mb-1">Workspace path (optional)</label>
-                <input type="text"
-                       {{ stimulus_target('chat-based-content-editor', 'workspacePath') }}
-                       name="workspace_path"
-                       id="workspace_path"
-                       value="{{ defaultWorkspacePath|default('') }}"
-                       placeholder="/path/to/workspace"
-                       class="w-full px-3 py-2 border border-dark-300 dark:border-dark-600 rounded-md bg-white dark:bg-dark-800 text-dark-900 dark:text-dark-100 text-sm">
-            </div>
-            <div>
                 <label for="instruction" class="block text-sm font-medium text-dark-700 dark:text-dark-300 mb-1">Instruction</label>
                 <textarea {{ stimulus_target('chat-based-content-editor', 'instruction') }}
+                          {{ stimulus_action('chat-based-content-editor', 'handleKeydown', 'keydown') }}
                           name="instruction"
                           id="instruction"
                           rows="3"
@@ -52,11 +62,41 @@
                           placeholder="e.g. Add a contact section to the homepage"
                           class="w-full px-3 py-2 border border-dark-300 dark:border-dark-600 rounded-md bg-white dark:bg-dark-800 text-dark-900 dark:text-dark-100 text-sm"></textarea>
             </div>
-            <button type="submit"
-                    {{ stimulus_target('chat-based-content-editor', 'submit') }}
-                    class="px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900 disabled:opacity-50 disabled:cursor-not-allowed">
-                Run
-            </button>
+            <div class="flex items-center gap-4">
+                <button type="submit"
+                        {{ stimulus_target('chat-based-content-editor', 'submit') }}
+                        class="px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900 disabled:opacity-50 disabled:cursor-not-allowed">
+                    Run
+                </button>
+                <label class="inline-flex items-center gap-1.5 text-sm text-dark-600 dark:text-dark-400 cursor-pointer select-none">
+                    <input type="checkbox"
+                           {{ stimulus_target('chat-based-content-editor', 'submitOnEnter') }}
+                           {{ stimulus_action('chat-based-content-editor', 'toggleSubmitOnEnter', 'change') }}
+                           checked
+                           class="rounded border-dark-300 dark:border-dark-600 text-primary-600 focus:ring-primary-500 dark:focus:ring-offset-dark-800">
+                    <span>Enter to send</span>
+                </label>
+            </div>
         </form>
+
+        <div class="border-t border-dark-200 dark:border-dark-700 pt-6">
+            <h2 class="text-lg font-medium text-dark-900 dark:text-dark-100 mb-3">Past Conversations</h2>
+            <div class="space-y-2">
+                {% if pastConversations is empty %}
+                    <p class="text-dark-500 dark:text-dark-400 text-sm">No past conversations yet.</p>
+                {% else %}
+                    {% for conv in pastConversations %}
+                        <a href="{{ path('chat_based_content_editor.presentation.show', { conversationId: conv.id }) }}"
+                           class="block w-full text-left p-3 rounded-lg border border-dark-200 dark:border-dark-700 hover:bg-dark-50 dark:hover:bg-dark-700/50 transition-colors">
+                            <div class="flex justify-between items-start gap-2">
+                                <span class="text-sm text-dark-900 dark:text-dark-100 line-clamp-2">{{ conv.preview ?: '(Empty conversation)' }}</span>
+                                <span class="text-xs text-dark-500 dark:text-dark-400 whitespace-nowrap">{{ conv.createdAt }}</span>
+                            </div>
+                            <div class="text-xs text-dark-500 dark:text-dark-400 mt-1">{{ conv.messageCount }} message{{ conv.messageCount != 1 ? 's' : '' }}</div>
+                        </a>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
# Problem Statement

Currently, when users interact with the AI content editor, each message is treated as a completely new conversation. The AI has no memory of what was discussed or done previously. This creates a frustrating experience where users must repeat context, re-explain their project, and can't build on previous work within a session.

# Desired Outcome

Users should be able to have natural, flowing conversations with the AI editor where it remembers what was said and done earlier. Just like chatting with a colleague, users should be able to say "now change the header color" without re-explaining which file they're working on or what the project is about.

# User Stories
- As a user, I want the AI to remember my previous instructions so I can give follow-up commands without repeating context
- As a user, I want to see my conversation history so I can review what was discussed
- As a user, I want to start new conversations when I'm working on something unrelated
- As a user, I want to switch between past conversations to continue previous work

# Success Criteria
- Users can send multiple messages and the AI responds with awareness of previous exchanges
- Conversation history is visible in the UI
- Users can start fresh conversations when needed
- Past conversations are accessible from a sidebar