### PR TITLE
 Feature: Conversation Memory for AI Chat Editor

### DIFF
--- a/migrations/Version20260120120440.php
+++ b/migrations/Version20260120120440.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260120120440 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Conversation entity and link EditSession to it; drop workspace_path from edit_sessions.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->connection->executeStatement('CREATE TABLE conversations (id CHAR(36) NOT NULL, workspace_path VARCHAR(4096) NOT NULL, created_at DATETIME NOT NULL, PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->connection->executeStatement('ALTER TABLE edit_sessions ADD conversation_id CHAR(36) DEFAULT NULL');
+
+        $rows = $this->connection->fetchAllAssociative('SELECT id, workspace_path, created_at FROM edit_sessions');
+        foreach ($rows as $row) {
+            $uuid = $this->connection->fetchOne('SELECT UUID()');
+            $this->connection->executeStatement(
+                'INSERT INTO conversations (id, workspace_path, created_at) VALUES (?, ?, ?)',
+                [$uuid, $row['workspace_path'], $row['created_at']]
+            );
+            $this->connection->executeStatement(
+                'UPDATE edit_sessions SET conversation_id = ? WHERE id = ?',
+                [$uuid, $row['id']]
+            );
+        }
+
+        $this->addSql('ALTER TABLE edit_sessions MODIFY conversation_id CHAR(36) NOT NULL');
+        $this->addSql('ALTER TABLE edit_sessions DROP workspace_path');
+        $this->addSql('ALTER TABLE edit_sessions ADD CONSTRAINT FK_B16E393A9AC0396 FOREIGN KEY (conversation_id) REFERENCES conversations (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_B16E393A9AC0396 ON edit_sessions (conversation_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE conversations');
+        $this->addSql('ALTER TABLE edit_sessions DROP FOREIGN KEY FK_B16E393A9AC0396');
+        $this->addSql('DROP INDEX IDX_B16E393A9AC0396 ON edit_sessions');
+        $this->addSql('ALTER TABLE edit_sessions ADD workspace_path VARCHAR(4096) NOT NULL, DROP conversation_id');
+    }
+}

--- a/migrations/Version20260120140000.php
+++ b/migrations/Version20260120140000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add conversation_messages table for multi-turn chat support.
+ */
+final class Version20260120140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add conversation_messages table for storing conversation history.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE conversation_messages (id INT AUTO_INCREMENT NOT NULL, conversation_id CHAR(36) NOT NULL, role VARCHAR(32) NOT NULL, content_json LONGTEXT NOT NULL, sequence INT NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_3B4CA1869AC0396 (conversation_id), INDEX idx_conversation_message_sequence (conversation_id, sequence), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE conversation_messages ADD CONSTRAINT FK_3B4CA1869AC0396 FOREIGN KEY (conversation_id) REFERENCES conversations (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE conversation_messages DROP FOREIGN KEY FK_3B4CA1869AC0396');
+        $this->addSql('DROP TABLE conversation_messages');
+    }
+}

--- a/migrations/Version20260120154059.php
+++ b/migrations/Version20260120154059.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260120154059 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE conversation_messages CHANGE created_at created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE conversation_messages CHANGE created_at created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+}

--- a/src/ChatBasedContentEditor/Domain/Entity/Conversation.php
+++ b/src/ChatBasedContentEditor/Domain/Entity/Conversation.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ChatBasedContentEditor\Domain\Entity;
+
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use EnterpriseToolingForSymfony\SharedBundle\DateAndTime\Service\DateAndTimeService;
+use Exception;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'conversations')]
+class Conversation
+{
+    /**
+     * @throws Exception
+     */
+    public function __construct(string $workspacePath)
+    {
+        $this->workspacePath = $workspacePath;
+        $this->createdAt     = DateAndTimeService::getDateTimeImmutable();
+        $this->editSessions  = new ArrayCollection();
+        $this->messages      = new ArrayCollection();
+    }
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[ORM\Column(
+        type: Types::GUID,
+        unique: true
+    )]
+    private ?string $id = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    #[ORM\Column(
+        type: Types::STRING,
+        length: 4096,
+        nullable: false
+    )]
+    private readonly string $workspacePath;
+
+    public function getWorkspacePath(): string
+    {
+        return $this->workspacePath;
+    }
+
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        nullable: false
+    )]
+    private readonly DateTimeImmutable $createdAt;
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @var Collection<int, EditSession>
+     */
+    #[ORM\OneToMany(
+        targetEntity: EditSession::class,
+        mappedBy: 'conversation',
+        cascade: ['persist', 'remove'],
+        orphanRemoval: true
+    )]
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
+    private Collection $editSessions;
+
+    /**
+     * @return Collection<int, EditSession>
+     */
+    public function getEditSessions(): Collection
+    {
+        return $this->editSessions;
+    }
+
+    /**
+     * @var Collection<int, ConversationMessage>
+     */
+    #[ORM\OneToMany(
+        targetEntity: ConversationMessage::class,
+        mappedBy: 'conversation',
+        cascade: ['persist', 'remove'],
+        orphanRemoval: true
+    )]
+    #[ORM\OrderBy(['sequence' => 'ASC'])]
+    private Collection $messages;
+
+    /**
+     * @return Collection<int, ConversationMessage>
+     */
+    public function getMessages(): Collection
+    {
+        return $this->messages;
+    }
+
+    public function addMessage(ConversationMessage $message): void
+    {
+        if (!$this->messages->contains($message)) {
+            $this->messages->add($message);
+        }
+    }
+
+    public function getNextMessageSequence(): int
+    {
+        $lastMessage = $this->messages->last();
+        if ($lastMessage === false) {
+            return 1;
+        }
+
+        return $lastMessage->getSequence() + 1;
+    }
+}

--- a/src/ChatBasedContentEditor/Domain/Entity/ConversationMessage.php
+++ b/src/ChatBasedContentEditor/Domain/Entity/ConversationMessage.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ChatBasedContentEditor\Domain\Entity;
+
+use App\ChatBasedContentEditor\Domain\Enum\ConversationMessageRole;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use EnterpriseToolingForSymfony\SharedBundle\DateAndTime\Service\DateAndTimeService;
+use Exception;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'conversation_messages')]
+#[ORM\Index(columns: ['conversation_id', 'sequence'], name: 'idx_conversation_message_sequence')]
+class ConversationMessage
+{
+    /**
+     * @throws Exception
+     */
+    public function __construct(
+        Conversation            $conversation,
+        ConversationMessageRole $role,
+        string                  $contentJson
+    ) {
+        $this->conversation = $conversation;
+        $this->role         = $role;
+        $this->contentJson  = $contentJson;
+        $this->sequence     = $conversation->getNextMessageSequence();
+        $this->createdAt    = DateAndTimeService::getDateTimeImmutable();
+
+        $conversation->addMessage($this);
+    }
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\Column(
+        type: Types::INTEGER
+    )]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    #[ORM\ManyToOne(
+        targetEntity: Conversation::class,
+        inversedBy: 'messages'
+    )]
+    #[ORM\JoinColumn(
+        nullable: false,
+        onDelete: 'CASCADE'
+    )]
+    private readonly Conversation $conversation;
+
+    public function getConversation(): Conversation
+    {
+        return $this->conversation;
+    }
+
+    #[ORM\Column(
+        type: Types::STRING,
+        length: 32,
+        nullable: false,
+        enumType: ConversationMessageRole::class
+    )]
+    private readonly ConversationMessageRole $role;
+
+    public function getRole(): ConversationMessageRole
+    {
+        return $this->role;
+    }
+
+    #[ORM\Column(
+        type: Types::TEXT,
+        nullable: false
+    )]
+    private readonly string $contentJson;
+
+    public function getContentJson(): string
+    {
+        return $this->contentJson;
+    }
+
+    #[ORM\Column(
+        type: Types::INTEGER,
+        nullable: false
+    )]
+    private readonly int $sequence;
+
+    public function getSequence(): int
+    {
+        return $this->sequence;
+    }
+
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        nullable: false
+    )]
+    private readonly DateTimeImmutable $createdAt;
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/ChatBasedContentEditor/Domain/Entity/EditSession.php
+++ b/src/ChatBasedContentEditor/Domain/Entity/EditSession.php
@@ -22,14 +22,14 @@ class EditSession
      * @throws Exception
      */
     public function __construct(
-        string $workspacePath,
-        string $instruction
+        Conversation $conversation,
+        string       $instruction
     ) {
-        $this->workspacePath = $workspacePath;
-        $this->instruction   = $instruction;
-        $this->status        = EditSessionStatus::Pending;
-        $this->createdAt     = DateAndTimeService::getDateTimeImmutable();
-        $this->chunks        = new ArrayCollection();
+        $this->conversation = $conversation;
+        $this->instruction  = $instruction;
+        $this->status       = EditSessionStatus::Pending;
+        $this->createdAt    = DateAndTimeService::getDateTimeImmutable();
+        $this->chunks       = new ArrayCollection();
     }
 
     #[ORM\Id]
@@ -46,16 +46,24 @@ class EditSession
         return $this->id;
     }
 
-    #[ORM\Column(
-        type: Types::STRING,
-        length: 4096,
-        nullable: false
+    #[ORM\ManyToOne(
+        targetEntity: Conversation::class,
+        inversedBy: 'editSessions'
     )]
-    private readonly string $workspacePath;
+    #[ORM\JoinColumn(
+        nullable: false,
+        onDelete: 'CASCADE'
+    )]
+    private readonly Conversation $conversation;
+
+    public function getConversation(): Conversation
+    {
+        return $this->conversation;
+    }
 
     public function getWorkspacePath(): string
     {
-        return $this->workspacePath;
+        return $this->conversation->getWorkspacePath();
     }
 
     #[ORM\Column(

--- a/src/ChatBasedContentEditor/Domain/Enum/ConversationMessageRole.php
+++ b/src/ChatBasedContentEditor/Domain/Enum/ConversationMessageRole.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ChatBasedContentEditor\Domain\Enum;
+
+/**
+ * Represents the role of a message in a conversation.
+ * These map to NeuronAI's MessageRole enum values.
+ */
+enum ConversationMessageRole: string
+{
+    case User           = 'user';
+    case Assistant      = 'assistant';
+    case ToolCall       = 'tool_call';
+    case ToolCallResult = 'tool_call_result';
+}

--- a/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
+++ b/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
@@ -7,15 +7,34 @@
          {{ stimulus_controller('chat-based-content-editor', {
              runUrl: runUrl,
              pollUrlTemplate: pollUrlTemplate,
-             workspacePath: defaultWorkspacePath|default('')
+             conversationId: conversation.id
          }) }}>
-        <h1 class="text-2xl font-semibold text-dark-900 dark:text-dark-100">Chat-based content editor</h1>
-        <p class="text-dark-600 dark:text-dark-400">Give instructions in natural language; the AI will edit files in the workspace and show what it does step by step.</p>
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-dark-900 dark:text-dark-100">Chat-based content editor</h1>
+                <p class="text-dark-600 dark:text-dark-400 mt-1">Give instructions in natural language; the AI will edit files in the workspace and show what it does step by step.</p>
+            </div>
+            <a href="{{ path('chat_based_content_editor.presentation.new') }}"
+               class="px-3 py-1.5 rounded-md border border-dark-300 dark:border-dark-600 text-dark-700 dark:text-dark-300 text-sm font-medium hover:bg-dark-100 dark:hover:bg-dark-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900">
+                New Conversation
+            </a>
+        </div>
 
         <div class="relative">
             <div {{ stimulus_target('chat-based-content-editor', 'messages') }}
                  class="rounded-lg border border-dark-200 dark:border-dark-700 bg-white dark:bg-dark-800 p-4 min-h-[320px] max-h-[500px] overflow-y-auto space-y-4">
-                <p class="text-dark-500 dark:text-dark-400 text-sm">Messages will appear here. Enter an instruction below and submit.</p>
+                {% if turns is empty %}
+                    <p class="text-dark-500 dark:text-dark-400 text-sm">Messages will appear here. Enter an instruction below and submit.</p>
+                {% else %}
+                    {% for turn in turns %}
+                        <div class="flex justify-end">
+                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-primary-100 dark:bg-primary-900/30 text-dark-900 dark:text-dark-100 text-sm">{{ turn.instruction }}</div>
+                        </div>
+                        <div class="flex justify-start">
+                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-dark-100 dark:bg-dark-700/50 text-dark-800 dark:text-dark-200 text-sm whitespace-pre-wrap {{ turn.status == 'failed' ? 'border-l-2 border-red-500 pl-2' : '' }}">{{ turn.response ?: '(No response)' }}</div>
+                        </div>
+                    {% endfor %}
+                {% endif %}
             </div>
             <div class="absolute bottom-2 right-2">
                 <label class="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-dark-100/80 dark:bg-dark-700/80 backdrop-blur-sm text-xs text-dark-600 dark:text-dark-300 cursor-pointer select-none">
@@ -33,18 +52,9 @@
               class="space-y-4">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('chat_based_content_editor_run') }}">
             <div>
-                <label for="workspace_path" class="block text-sm font-medium text-dark-700 dark:text-dark-300 mb-1">Workspace path (optional)</label>
-                <input type="text"
-                       {{ stimulus_target('chat-based-content-editor', 'workspacePath') }}
-                       name="workspace_path"
-                       id="workspace_path"
-                       value="{{ defaultWorkspacePath|default('') }}"
-                       placeholder="/path/to/workspace"
-                       class="w-full px-3 py-2 border border-dark-300 dark:border-dark-600 rounded-md bg-white dark:bg-dark-800 text-dark-900 dark:text-dark-100 text-sm">
-            </div>
-            <div>
                 <label for="instruction" class="block text-sm font-medium text-dark-700 dark:text-dark-300 mb-1">Instruction</label>
                 <textarea {{ stimulus_target('chat-based-content-editor', 'instruction') }}
+                          {{ stimulus_action('chat-based-content-editor', 'handleKeydown', 'keydown') }}
                           name="instruction"
                           id="instruction"
                           rows="3"
@@ -52,11 +62,41 @@
                           placeholder="e.g. Add a contact section to the homepage"
                           class="w-full px-3 py-2 border border-dark-300 dark:border-dark-600 rounded-md bg-white dark:bg-dark-800 text-dark-900 dark:text-dark-100 text-sm"></textarea>
             </div>
-            <button type="submit"
-                    {{ stimulus_target('chat-based-content-editor', 'submit') }}
-                    class="px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900 disabled:opacity-50 disabled:cursor-not-allowed">
-                Run
-            </button>
+            <div class="flex items-center gap-4">
+                <button type="submit"
+                        {{ stimulus_target('chat-based-content-editor', 'submit') }}
+                        class="px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900 disabled:opacity-50 disabled:cursor-not-allowed">
+                    Run
+                </button>
+                <label class="inline-flex items-center gap-1.5 text-sm text-dark-600 dark:text-dark-400 cursor-pointer select-none">
+                    <input type="checkbox"
+                           {{ stimulus_target('chat-based-content-editor', 'submitOnEnter') }}
+                           {{ stimulus_action('chat-based-content-editor', 'toggleSubmitOnEnter', 'change') }}
+                           checked
+                           class="rounded border-dark-300 dark:border-dark-600 text-primary-600 focus:ring-primary-500 dark:focus:ring-offset-dark-800">
+                    <span>Enter to send</span>
+                </label>
+            </div>
         </form>
+
+        <div class="border-t border-dark-200 dark:border-dark-700 pt-6">
+            <h2 class="text-lg font-medium text-dark-900 dark:text-dark-100 mb-3">Past Conversations</h2>
+            <div class="space-y-2">
+                {% if pastConversations is empty %}
+                    <p class="text-dark-500 dark:text-dark-400 text-sm">No past conversations yet.</p>
+                {% else %}
+                    {% for conv in pastConversations %}
+                        <a href="{{ path('chat_based_content_editor.presentation.show', { conversationId: conv.id }) }}"
+                           class="block w-full text-left p-3 rounded-lg border border-dark-200 dark:border-dark-700 hover:bg-dark-50 dark:hover:bg-dark-700/50 transition-colors">
+                            <div class="flex justify-between items-start gap-2">
+                                <span class="text-sm text-dark-900 dark:text-dark-100 line-clamp-2">{{ conv.preview ?: '(Empty conversation)' }}</span>
+                                <span class="text-xs text-dark-500 dark:text-dark-400 whitespace-nowrap">{{ conv.createdAt }}</span>
+                            </div>
+                            <div class="text-xs text-dark-500 dark:text-dark-400 mt-1">{{ conv.messageCount }} message{{ conv.messageCount != 1 ? 's' : '' }}</div>
+                        </a>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
     </div>
 {% endblock %}

--- a/src/LlmContentEditor/Facade/Dto/ConversationMessageDto.php
+++ b/src/LlmContentEditor/Facade/Dto/ConversationMessageDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\LlmContentEditor\Facade\Dto;
+
+/**
+ * DTO representing a message in a conversation for cross-vertical communication.
+ * The role maps to NeuronAI message types (user, assistant, tool_call, tool_call_result).
+ */
+readonly class ConversationMessageDto
+{
+    /**
+     * @param 'user'|'assistant'|'tool_call'|'tool_call_result' $role
+     */
+    public function __construct(
+        public string $role,
+        public string $contentJson,
+    ) {
+    }
+}

--- a/src/LlmContentEditor/Facade/Dto/EditStreamChunkDto.php
+++ b/src/LlmContentEditor/Facade/Dto/EditStreamChunkDto.php
@@ -7,14 +7,15 @@ namespace App\LlmContentEditor\Facade\Dto;
 readonly class EditStreamChunkDto
 {
     /**
-     * @param 'text'|'event'|'done' $chunkType
+     * @param 'text'|'event'|'message'|'done' $chunkType
      */
     public function __construct(
-        public string         $chunkType,
-        public ?string        $content = null,
-        public ?AgentEventDto $event = null,
-        public ?bool          $success = null,
-        public ?string        $errorMessage = null,
+        public string                  $chunkType,
+        public ?string                 $content = null,
+        public ?AgentEventDto          $event = null,
+        public ?bool                   $success = null,
+        public ?string                 $errorMessage = null,
+        public ?ConversationMessageDto $message = null,
     ) {
     }
 }

--- a/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
+++ b/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
@@ -5,35 +5,114 @@ declare(strict_types=1);
 namespace App\LlmContentEditor\Facade;
 
 use App\LlmContentEditor\Domain\Agent\ContentEditorAgent;
+use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
 use App\LlmContentEditor\Facade\Dto\EditStreamChunkDto;
 use App\LlmContentEditor\Infrastructure\AgentEventQueue;
+use App\LlmContentEditor\Infrastructure\ChatHistory\CallbackChatHistory;
+use App\LlmContentEditor\Infrastructure\ChatHistory\MessageSerializer;
 use App\LlmContentEditor\Infrastructure\Observer\AgentEventCollectingObserver;
 use App\WorkspaceTooling\Facade\WorkspaceToolingServiceInterface;
 use Generator;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\Message;
+use NeuronAI\Chat\Messages\ToolCallMessage;
+use NeuronAI\Chat\Messages\ToolCallResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
+use SplQueue;
 use Throwable;
+
+use function is_string;
 
 final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
 {
+    private readonly MessageSerializer $messageSerializer;
+
     public function __construct(
         private readonly WorkspaceToolingServiceInterface $workspaceTooling
     ) {
+        $this->messageSerializer = new MessageSerializer();
     }
 
     /**
+     * @deprecated Use streamEditWithHistory() to support multi-turn conversations
+     *
      * @return Generator<EditStreamChunkDto>
      */
     public function streamEdit(string $workspacePath, string $instruction): Generator
     {
-        // Always include the working folder so the agent uses it for all path-based tools.
-        // Omitting it led to the agent guessing /workspace and retrying get_folder_content in a loop.
-        $prompt = sprintf(
-            'The working folder is: %s' . "\n\n" . 'Please perform the following task: %s',
-            $workspacePath,
-            $instruction
-        );
+        // Delegate to streamEditWithHistory with empty history
+        yield from $this->streamEditWithHistory($workspacePath, $instruction, []);
+    }
+
+    /**
+     * @param list<ConversationMessageDto> $previousMessages
+     *
+     * @return Generator<EditStreamChunkDto>
+     */
+    public function streamEditWithHistory(
+        string $workspacePath,
+        string $instruction,
+        array  $previousMessages = []
+    ): Generator {
+        // Convert previous message DTOs to NeuronAI messages
+        $initialMessages = [];
+        foreach ($previousMessages as $dto) {
+            try {
+                $initialMessages[] = $this->messageSerializer->fromDto($dto);
+            } catch (Throwable) {
+                // Skip invalid messages
+            }
+        }
+
+        // Determine if this is the first message (needs workspace context)
+        $isFirstMessage = $initialMessages === [];
+
+        // Build the user prompt
+        if ($isFirstMessage) {
+            $prompt = sprintf(
+                'The working folder is: %s' . "\n\n" . 'Please perform the following task: %s',
+                $workspacePath,
+                $instruction
+            );
+        } else {
+            // Follow-up messages don't need the workspace context repeated
+            $prompt = $instruction;
+        }
+
+        // Create a queue to collect new messages for persistence
+        /** @var SplQueue<ConversationMessageDto> $messageQueue */
+        $messageQueue = new SplQueue();
+
+        // Create chat history with previous messages and a callback for new ones
+        $chatHistory = new CallbackChatHistory($initialMessages);
+        $chatHistory->setOnNewMessageCallback(function (Message $message) use ($messageQueue): void {
+            // Only persist user and assistant messages for conversation history.
+            // Tool call/result messages are internal to a single turn and cause
+            // OpenAI API format issues when replayed (400 Bad Request).
+            //
+            // Additionally, only save messages with actual content to avoid
+            // empty or intermediate messages during tool usage flows.
+            $shouldSave = match (true) {
+                $message instanceof UserMessage      && !$message instanceof ToolCallResultMessage => true,
+                $message instanceof AssistantMessage && !$message instanceof ToolCallMessage       => $this->hasNonEmptyContent($message),
+                default                                                                            => false,
+            };
+
+            if (!$shouldSave) {
+                return;
+            }
+
+            try {
+                $dto = $this->messageSerializer->toDto($message);
+                $messageQueue->enqueue($dto);
+            } catch (Throwable) {
+                // Skip messages that can't be serialized
+            }
+        });
 
         $agent = new ContentEditorAgent($this->workspaceTooling);
+        $agent->withChatHistory($chatHistory);
+
         $queue = new AgentEventQueue();
         $agent->attach(new AgentEventCollectingObserver($queue));
 
@@ -42,12 +121,22 @@ final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
             $stream  = $agent->stream($message);
 
             foreach ($stream as $chunk) {
+                // Yield any queued messages for persistence
+                while (!$messageQueue->isEmpty()) {
+                    yield new EditStreamChunkDto('message', null, null, null, null, $messageQueue->dequeue());
+                }
+
                 foreach ($queue->drain() as $eventDto) {
                     yield new EditStreamChunkDto('event', null, $eventDto, null, null);
                 }
                 if (is_string($chunk)) {
                     yield new EditStreamChunkDto('text', $chunk, null, null, null);
                 }
+            }
+
+            // Yield any remaining queued messages
+            while (!$messageQueue->isEmpty()) {
+                yield new EditStreamChunkDto('message', null, null, null, null, $messageQueue->dequeue());
             }
 
             foreach ($queue->drain() as $eventDto) {
@@ -58,5 +147,24 @@ final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
         } catch (Throwable $e) {
             yield new EditStreamChunkDto('done', null, null, false, $e->getMessage());
         }
+    }
+
+    /**
+     * Check if a message has non-empty content worth persisting.
+     */
+    private function hasNonEmptyContent(Message $message): bool
+    {
+        $content = $message->getContent();
+
+        if ($content === null) {
+            return false;
+        }
+
+        if (is_string($content)) {
+            return trim($content) !== '';
+        }
+
+        // Arrays or other types - consider them as having content
+        return true;
     }
 }

--- a/src/LlmContentEditor/Facade/LlmContentEditorFacadeInterface.php
+++ b/src/LlmContentEditor/Facade/LlmContentEditorFacadeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\LlmContentEditor\Facade;
 
+use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
 use App\LlmContentEditor\Facade\Dto\EditStreamChunkDto;
 use Generator;
 
@@ -14,7 +15,23 @@ interface LlmContentEditorFacadeInterface
      * Yields streaming chunks: event (structured agent feedback), text (LLM output), and done.
      * The caller is responsible for resolving and validating workspacePath (e.g. under an allowed root).
      *
+     * @deprecated Use streamEditWithHistory() to support multi-turn conversations
+     *
      * @return Generator<EditStreamChunkDto>
      */
     public function streamEdit(string $workspacePath, string $instruction): Generator;
+
+    /**
+     * Runs the content editor agent with conversation history support.
+     * Yields streaming chunks: event, text, message (new messages to persist), and done.
+     *
+     * @param list<ConversationMessageDto> $previousMessages Messages from earlier turns in this conversation
+     *
+     * @return Generator<EditStreamChunkDto>
+     */
+    public function streamEditWithHistory(
+        string $workspacePath,
+        string $instruction,
+        array  $previousMessages = []
+    ): Generator;
 }

--- a/src/LlmContentEditor/Infrastructure/ChatHistory/CallbackChatHistory.php
+++ b/src/LlmContentEditor/Infrastructure/ChatHistory/CallbackChatHistory.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\LlmContentEditor\Infrastructure\ChatHistory;
+
+use Closure;
+use NeuronAI\Chat\History\AbstractChatHistory;
+use NeuronAI\Chat\History\ChatHistoryInterface;
+use NeuronAI\Chat\Messages\Message;
+use Override;
+
+/**
+ * A ChatHistory implementation that:
+ * 1. Can be pre-loaded with messages from a previous conversation
+ * 2. Notifies via callback when new messages are added (for persistence)
+ *
+ * This allows the facade to manage conversation history without directly
+ * depending on database entities.
+ */
+class CallbackChatHistory extends AbstractChatHistory
+{
+    /**
+     * @var Closure(Message): void|null
+     */
+    private ?Closure $onNewMessage = null;
+
+    /**
+     * @param list<Message> $initialMessages Messages from previous conversation turns
+     * @param int           $contextWindow   Maximum token count for context window
+     */
+    public function __construct(
+        array $initialMessages = [],
+        int   $contextWindow = 50000
+    ) {
+        parent::__construct($contextWindow);
+        $this->history = $initialMessages;
+    }
+
+    /**
+     * Set a callback that will be called when a new message is added.
+     * The callback receives the Message object.
+     *
+     * @param Closure(Message): void $callback
+     */
+    public function setOnNewMessageCallback(Closure $callback): self
+    {
+        $this->onNewMessage = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Called when a new message is added to the history.
+     * We use this hook to notify the callback.
+     */
+    protected function onNewMessage(Message $message): void
+    {
+        if ($this->onNewMessage !== null) {
+            ($this->onNewMessage)($message);
+        }
+    }
+
+    /**
+     * Required by AbstractChatHistory.
+     * Since we manage persistence externally via callback, this is a no-op.
+     *
+     * @param list<Message> $messages
+     */
+    #[Override]
+    public function setMessages(array $messages): ChatHistoryInterface
+    {
+        // Persistence is handled externally via callback
+        return $this;
+    }
+
+    /**
+     * Required by AbstractChatHistory.
+     * Since we don't manage a persistent store, this is a no-op.
+     */
+    protected function clear(): ChatHistoryInterface
+    {
+        // Persistence is handled externally
+        return $this;
+    }
+}

--- a/src/LlmContentEditor/Infrastructure/ChatHistory/MessageSerializer.php
+++ b/src/LlmContentEditor/Infrastructure/ChatHistory/MessageSerializer.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\LlmContentEditor\Infrastructure\ChatHistory;
+
+use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
+use JsonException;
+use NeuronAI\Chat\Enums\MessageRole;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\Message;
+use NeuronAI\Chat\Messages\ToolCallMessage;
+use NeuronAI\Chat\Messages\ToolCallResultMessage;
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\Tools\Tool;
+
+use function array_map;
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Handles serialization and deserialization of NeuronAI messages to/from DTOs.
+ */
+final class MessageSerializer
+{
+    /**
+     * Convert a NeuronAI Message to a ConversationMessageDto.
+     *
+     * @throws JsonException
+     */
+    public function toDto(Message $message): ConversationMessageDto
+    {
+        $role        = $this->determineRole($message);
+        $contentJson = $this->serializeContent($message);
+
+        return new ConversationMessageDto($role, $contentJson);
+    }
+
+    /**
+     * Convert a ConversationMessageDto back to a NeuronAI Message.
+     *
+     * @throws JsonException
+     */
+    public function fromDto(ConversationMessageDto $dto): Message
+    {
+        /** @var array<string, mixed> $data */
+        $data = json_decode($dto->contentJson, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var string $content */
+        $content = $data['content'] ?? '';
+
+        return match ($dto->role) {
+            'user'      => new UserMessage($content),
+            'assistant' => new AssistantMessage($content !== '' ? $content : null),
+            'tool_call' => $this->deserializeToolCall($data),
+            default     => $this->deserializeToolCallResult($data),
+        };
+    }
+
+    /**
+     * @return 'user'|'assistant'|'tool_call'|'tool_call_result'
+     */
+    private function determineRole(Message $message): string
+    {
+        if ($message instanceof ToolCallMessage) {
+            return 'tool_call';
+        }
+
+        if ($message instanceof ToolCallResultMessage) {
+            return 'tool_call_result';
+        }
+
+        return match ($message->getRole()) {
+            MessageRole::USER->value      => 'user',
+            MessageRole::ASSISTANT->value => 'assistant',
+            default                       => 'assistant',
+        };
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function serializeContent(Message $message): string
+    {
+        if ($message instanceof ToolCallMessage) {
+            return $this->serializeToolCall($message);
+        }
+
+        if ($message instanceof ToolCallResultMessage) {
+            return $this->serializeToolCallResult($message);
+        }
+
+        return json_encode(['content' => $message->getContent()], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function serializeToolCall(ToolCallMessage $message): string
+    {
+        $tools = [];
+        foreach ($message->getTools() as $tool) {
+            if (!$tool instanceof Tool) {
+                continue;
+            }
+            $tools[] = [
+                'name'        => $tool->getName(),
+                'description' => $tool->getDescription(),
+                'inputs'      => $tool->getInputs(),
+                'callId'      => $tool->getCallId(),
+            ];
+        }
+
+        return json_encode([
+            'content' => $message->getContent(),
+            'tools'   => $tools,
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function serializeToolCallResult(ToolCallResultMessage $message): string
+    {
+        $tools = [];
+        foreach ($message->getTools() as $tool) {
+            if (!$tool instanceof Tool) {
+                continue;
+            }
+            $tools[] = [
+                'name'        => $tool->getName(),
+                'description' => $tool->getDescription(),
+                'inputs'      => $tool->getInputs(),
+                'callId'      => $tool->getCallId(),
+                'result'      => $tool->getResult(),
+            ];
+        }
+
+        return json_encode(['tools' => $tools], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeToolCall(array $data): ToolCallMessage
+    {
+        /** @var list<array{name: string, description: string, inputs: array<string, mixed>, callId: string|null}> $toolsData */
+        $toolsData = $data['tools'] ?? [];
+
+        $tools = array_map(
+            static fn (array $toolData): Tool => Tool::make($toolData['name'], $toolData['description'])
+                ->setInputs($toolData['inputs'])
+                ->setCallId($toolData['callId'] ?? null),
+            $toolsData
+        );
+
+        /** @var string|null $content */
+        $content = $data['content'] ?? null;
+
+        return new ToolCallMessage($content, $tools);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeToolCallResult(array $data): ToolCallResultMessage
+    {
+        /** @var list<array{name: string, description: string, inputs: array<string, mixed>, callId: string, result: string}> $toolsData */
+        $toolsData = $data['tools'] ?? [];
+
+        $tools = array_map(
+            static fn (array $toolData): Tool => Tool::make($toolData['name'], $toolData['description'])
+                ->setInputs($toolData['inputs'])
+                ->setCallId($toolData['callId'])
+                ->setResult($toolData['result']),
+            $toolsData
+        );
+
+        return new ToolCallResultMessage($tools);
+    }
+}


### PR DESCRIPTION
# Problem Statement

Currently, when users interact with the AI content editor, each message is treated as a completely new conversation. The AI has no memory of what was discussed or done previously. This creates a frustrating experience where users must repeat context, re-explain their project, and can't build on previous work within a session.

# Desired Outcome

Users should be able to have natural, flowing conversations with the AI editor where it remembers what was said and done earlier. Just like chatting with a colleague, users should be able to say "now change the header color" without re-explaining which file they're working on or what the project is about.

# User Stories
- As a user, I want the AI to remember my previous instructions so I can give follow-up commands without repeating context
- As a user, I want to see my conversation history so I can review what was discussed
- As a user, I want to start new conversations when I'm working on something unrelated
- As a user, I want to switch between past conversations to continue previous work

# Success Criteria
- Users can send multiple messages and the AI responds with awareness of previous exchanges
- Conversation history is visible in the UI
- Users can start fresh conversations when needed
- Past conversations are accessible from a sidebar

This superseded #8