### PR TITLE
Sync conversation state on page reload

### DIFF
--- a/src/ChatBasedContentEditor/Presentation/Controller/ChatBasedContentEditorController.php
+++ b/src/ChatBasedContentEditor/Presentation/Controller/ChatBasedContentEditorController.php
@@ -244,12 +244,20 @@ final class ChatBasedContentEditorController extends AbstractController
             }
 
             $assistantResponse = '';
+            $eventChunks       = [];
             foreach ($session->getChunks() as $chunk) {
-                if ($chunk->getChunkType()->value === 'text') {
+                $chunkType = $chunk->getChunkType()->value;
+                if ($chunkType === 'text') {
                     $payload = json_decode($chunk->getPayloadJson(), true);
                     if (is_array($payload) && array_key_exists('content', $payload) && is_string($payload['content'])) {
                         $assistantResponse .= $payload['content'];
                     }
+                } elseif ($chunkType === 'event') {
+                    $eventChunks[] = [
+                        'id'        => $chunk->getId(),
+                        'chunkType' => $chunkType,
+                        'payload'   => $chunk->getPayloadJson(),
+                    ];
                 }
             }
 
@@ -257,6 +265,7 @@ final class ChatBasedContentEditorController extends AbstractController
                 'instruction' => $session->getInstruction(),
                 'response'    => $assistantResponse,
                 'status'      => $sessionStatus->value,
+                'events'      => $eventChunks,
             ];
         }
 

--- a/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
+++ b/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
@@ -10,7 +10,8 @@
              conversationId: conversation.id,
              contextUsage: contextUsage,
              contextUsageUrl: contextUsageUrl,
-             activeSession: activeSession
+             activeSession: activeSession,
+             turns: turns
          }) }}>
 
         {# Flash messages #}


### PR DESCRIPTION
- Detect active (Pending/Running) sessions on page load
- Resume polling for in-progress sessions after navigation
- Show "Working..." state and disable input when session is active
- Replay existing chunks to restore UI state
- Display technical tool boxes for all completed turns
- Show Done/Failed status with expandable event details