### PR TITLE
feat(chat): add client-side markdown rendering for agent messages

### DIFF
--- a/assets/bootstrap.ts
+++ b/assets/bootstrap.ts
@@ -5,6 +5,7 @@ import { webuiBootstrap } from "@enterprise-tooling-for-symfony/webui";
 import ChatBasedContentEditorController from "../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/chat_based_content_editor_controller.ts";
 import ConversationHeartbeatController from "../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/conversation_heartbeat_controller.ts";
 import DistFilesController from "../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/dist_files_controller.ts";
+import MarkdownController from "../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_controller.ts";
 import WorkspaceSetupController from "../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/workspace_setup_controller.ts";
 
 const app = startStimulusApp();
@@ -12,6 +13,7 @@ const app = startStimulusApp();
 app.register("chat-based-content-editor", ChatBasedContentEditorController);
 app.register("conversation-heartbeat", ConversationHeartbeatController);
 app.register("dist-files", DistFilesController);
+app.register("markdown", MarkdownController);
 app.register("workspace-setup", WorkspaceSetupController);
 
 webuiBootstrap(app);

--- a/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/chat_based_content_editor_controller.ts
+++ b/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/chat_based_content_editor_controller.ts
@@ -15,6 +15,7 @@ import {
     getWorkingContainerStyle,
     getProgressAnimationState,
 } from "./chat_editor_helpers.ts";
+import { renderMarkdown } from "./markdown_renderer.ts";
 
 export default class extends Controller {
     static values = {
@@ -519,7 +520,12 @@ export default class extends Controller {
 
         if (chunk.chunkType === "text" && payload.content) {
             const textEl = this.getOrCreateTextElement(container);
-            textEl.textContent += payload.content;
+            // Append to raw markdown content stored in data attribute
+            const currentRaw = textEl.dataset.rawMarkdown || "";
+            const newRaw = currentRaw + payload.content;
+            textEl.dataset.rawMarkdown = newRaw;
+            // Render markdown to HTML
+            textEl.innerHTML = renderMarkdown(newRaw, { streaming: true });
             this.scrollToBottom();
         } else if (chunk.chunkType === "event") {
             const event = payloadToAgentEvent(payload);

--- a/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_controller.ts
+++ b/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_controller.ts
@@ -1,0 +1,117 @@
+import { Controller } from "@hotwired/stimulus";
+import { renderMarkdown } from "./markdown_renderer.ts";
+
+/**
+ * Stimulus controller for rendering markdown content.
+ *
+ * This controller manages a markdown source and renders it to HTML.
+ * It's designed to work with streaming content where markdown may be
+ * appended incrementally.
+ *
+ * Usage:
+ * ```html
+ * <div data-controller="markdown"
+ *      data-markdown-streaming-value="true">
+ * </div>
+ * ```
+ *
+ * The controller exposes methods to append and set content programmatically:
+ * - `appendContent(text: string)`: Append text to the markdown source
+ * - `setContent(text: string)`: Replace the entire markdown source
+ * - `getContent(): string`: Get the current raw markdown content
+ */
+export default class MarkdownController extends Controller {
+    static values = {
+        /**
+         * When true, the renderer handles potentially incomplete markdown
+         * more gracefully (e.g., unclosed code blocks).
+         */
+        streaming: { type: Boolean, default: true },
+    };
+
+    declare readonly streamingValue: boolean;
+
+    /**
+     * The raw markdown content that will be rendered.
+     */
+    private rawContent: string = "";
+
+    /**
+     * Whether a render is already scheduled (for debouncing rapid updates).
+     */
+    private renderScheduled: boolean = false;
+
+    connect(): void {
+        // Initial render if there's already content
+        if (this.element.textContent) {
+            this.rawContent = this.element.textContent;
+            this.render();
+        }
+    }
+
+    /**
+     * Appends text to the markdown content and re-renders.
+     * This is the primary method for streaming content.
+     */
+    appendContent(text: string): void {
+        this.rawContent += text;
+        this.scheduleRender();
+    }
+
+    /**
+     * Sets the entire markdown content and re-renders.
+     */
+    setContent(text: string): void {
+        this.rawContent = text;
+        this.scheduleRender();
+    }
+
+    /**
+     * Returns the current raw markdown content.
+     */
+    getContent(): string {
+        return this.rawContent;
+    }
+
+    /**
+     * Clears all content.
+     */
+    clear(): void {
+        this.rawContent = "";
+        (this.element as HTMLElement).innerHTML = "";
+    }
+
+    /**
+     * Schedules a render on the next animation frame.
+     * This debounces rapid updates that can occur during streaming.
+     */
+    private scheduleRender(): void {
+        if (this.renderScheduled) {
+            return;
+        }
+
+        this.renderScheduled = true;
+        requestAnimationFrame(() => {
+            this.render();
+            this.renderScheduled = false;
+        });
+    }
+
+    /**
+     * Renders the current markdown content to HTML.
+     */
+    private render(): void {
+        const html = renderMarkdown(this.rawContent, {
+            streaming: this.streamingValue,
+        });
+
+        (this.element as HTMLElement).innerHTML = html;
+
+        // Dispatch an event for parent controllers that may need to react
+        this.dispatch("rendered", {
+            detail: {
+                contentLength: this.rawContent.length,
+            },
+        });
+    }
+}

--- a/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_renderer.ts
+++ b/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_renderer.ts
@@ -1,0 +1,322 @@
+/**
+ * Lightweight markdown renderer for chat messages.
+ *
+ * Handles common markdown patterns with XSS prevention.
+ * Designed to work with streaming content where markdown may be incomplete.
+ */
+
+/**
+ * Escapes HTML special characters to prevent XSS.
+ */
+export function escapeHtmlForMarkdown(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+/**
+ * Renders a fenced code block with optional language highlighting hint.
+ */
+function renderCodeBlock(code: string, language: string): string {
+    const escapedCode = escapeHtmlForMarkdown(code);
+    const langClass = language ? ` class="language-${escapeHtmlForMarkdown(language)}"` : "";
+    return `<pre class="bg-dark-100 dark:bg-dark-800 rounded-md p-3 overflow-x-auto my-2"><code${langClass}>${escapedCode}</code></pre>`;
+}
+
+/**
+ * Renders inline code.
+ */
+function renderInlineCode(code: string): string {
+    return `<code class="bg-dark-100 dark:bg-dark-700 px-1.5 py-0.5 rounded text-sm font-mono">${escapeHtmlForMarkdown(code)}</code>`;
+}
+
+/**
+ * Placeholder token for inline code to prevent further processing.
+ */
+const CODE_PLACEHOLDER_PREFIX = "\x00CODE_";
+const CODE_PLACEHOLDER_SUFFIX = "_EDOC\x00";
+
+/**
+ * Processes inline markdown elements (bold, italic, code, links).
+ * Text should NOT be escaped yet - this function handles escaping.
+ */
+function processInlineMarkdown(text: string): string {
+    // First, extract and protect inline code blocks
+    const codeBlocks: string[] = [];
+    text = text.replace(/(?<!`)`([^`\n]+?)`(?!`)/g, (_, code) => {
+        const index = codeBlocks.length;
+        codeBlocks.push(code);
+        return `${CODE_PLACEHOLDER_PREFIX}${index}${CODE_PLACEHOLDER_SUFFIX}`;
+    });
+
+    // Now escape HTML in the remaining text
+    text = escapeHtmlForMarkdown(text);
+
+    // Bold: **text** or __text__ (allow any characters except newlines)
+    text = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    text = text.replace(/__(.+?)__/g, "<strong>$1</strong>");
+
+    // Italic: *text* or _text_ (but not inside words for underscore)
+    text = text.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, "<em>$1</em>");
+    text = text.replace(/(?<![a-zA-Z0-9])_([^_\n]+?)_(?![a-zA-Z0-9])/g, "<em>$1</em>");
+
+    // Links: [text](url)
+    text = text.replace(/\[([^\]]+?)\]\(([^)]+?)\)/g, (_, linkText, url) => {
+        // Validate URL to prevent javascript: and other dangerous protocols
+        const safeUrl = sanitizeUrl(url);
+        return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-primary-400 underline hover:no-underline">${linkText}</a>`;
+    });
+
+    // Restore code blocks (with proper escaping)
+    text = text.replace(new RegExp(`${CODE_PLACEHOLDER_PREFIX}(\\d+)${CODE_PLACEHOLDER_SUFFIX}`, "g"), (_, index) => {
+        const code = codeBlocks[parseInt(index, 10)];
+        return renderInlineCode(code);
+    });
+
+    return text;
+}
+
+/**
+ * Sanitizes a URL to prevent XSS via javascript: or data: protocols.
+ */
+function sanitizeUrl(url: string): string {
+    const trimmed = url.trim().toLowerCase();
+    if (trimmed.startsWith("javascript:") || trimmed.startsWith("data:") || trimmed.startsWith("vbscript:")) {
+        return "#";
+    }
+    return escapeHtmlForMarkdown(url);
+}
+
+/**
+ * Parses and renders a list (ordered or unordered).
+ */
+function renderList(lines: string[], startIndex: number): { html: string; endIndex: number } {
+    const firstLine = lines[startIndex];
+    const isOrdered = /^\d+\.\s/.test(firstLine);
+    const listItems: string[] = [];
+    let i = startIndex;
+
+    const listPattern = isOrdered ? /^(\d+)\.\s(.*)$/ : /^[-*+]\s(.*)$/;
+
+    while (i < lines.length) {
+        const line = lines[i];
+        const match = line.match(listPattern);
+        if (!match) {
+            break;
+        }
+
+        const content = isOrdered ? match[2] : match[1];
+        listItems.push(`<li>${processInlineMarkdown(content)}</li>`);
+        i++;
+    }
+
+    const tag = isOrdered ? "ol" : "ul";
+    const listClass = isOrdered ? "list-decimal list-inside my-2 space-y-1" : "list-disc list-inside my-2 space-y-1";
+
+    return {
+        html: `<${tag} class="${listClass}">${listItems.join("")}</${tag}>`,
+        endIndex: i - 1,
+    };
+}
+
+/**
+ * Checks if a line is a list item.
+ */
+function isListItem(line: string): boolean {
+    return /^[-*+]\s/.test(line) || /^\d+\.\s/.test(line);
+}
+
+/**
+ * Checks if a line is a header.
+ */
+function isHeader(line: string): boolean {
+    return /^#{1,6}\s/.test(line);
+}
+
+/**
+ * Renders a header line.
+ */
+function renderHeader(line: string): string {
+    const match = line.match(/^(#{1,6})\s(.*)$/);
+    if (!match) {
+        return `<p>${processInlineMarkdown(line)}</p>`;
+    }
+
+    const level = match[1].length;
+    const content = match[2];
+
+    const sizeClasses: Record<number, string> = {
+        1: "text-xl font-bold my-3",
+        2: "text-lg font-bold my-2",
+        3: "text-base font-semibold my-2",
+        4: "text-sm font-semibold my-1",
+        5: "text-sm font-medium my-1",
+        6: "text-xs font-medium my-1",
+    };
+
+    const classes = sizeClasses[level] || sizeClasses[6];
+    return `<h${level} class="${classes}">${processInlineMarkdown(content)}</h${level}>`;
+}
+
+/**
+ * Configuration options for markdown rendering.
+ */
+export interface MarkdownRenderOptions {
+    /**
+     * When true, handles potentially incomplete markdown more gracefully.
+     * For example, unclosed code blocks are rendered as-is rather than
+     * treating all subsequent content as code.
+     */
+    streaming?: boolean;
+}
+
+/**
+ * Renders markdown text to HTML.
+ *
+ * Supports:
+ * - Bold: **text** or __text__
+ * - Italic: *text* or _text_
+ * - Inline code: `code`
+ * - Code blocks: ```language ... ```
+ * - Headers: # to ######
+ * - Unordered lists: - item, * item, + item
+ * - Ordered lists: 1. item
+ * - Links: [text](url)
+ * - Paragraphs and line breaks
+ *
+ * @param markdown The markdown text to render
+ * @param options Rendering options
+ * @returns HTML string
+ */
+export function renderMarkdown(markdown: string, options: MarkdownRenderOptions = {}): string {
+    if (!markdown) {
+        return "";
+    }
+
+    const { streaming = false } = options;
+    const lines = markdown.split("\n");
+    const output: string[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+        const line = lines[i];
+
+        // Check for fenced code block
+        if (line.startsWith("```")) {
+            const language = line.slice(3).trim();
+            const codeLines: string[] = [];
+            i++;
+
+            // Find closing fence
+            let foundClosing = false;
+            while (i < lines.length) {
+                if (lines[i].startsWith("```")) {
+                    foundClosing = true;
+                    i++;
+                    break;
+                }
+                codeLines.push(lines[i]);
+                i++;
+            }
+
+            if (foundClosing || !streaming) {
+                // Render as code block
+                output.push(renderCodeBlock(codeLines.join("\n"), language));
+            } else {
+                // In streaming mode with unclosed code block, render what we have
+                // but indicate it's still being streamed
+                output.push(renderCodeBlock(codeLines.join("\n"), language));
+            }
+            continue;
+        }
+
+        // Check for header
+        if (isHeader(line)) {
+            output.push(renderHeader(line));
+            i++;
+            continue;
+        }
+
+        // Check for list
+        if (isListItem(line)) {
+            const listResult = renderList(lines, i);
+            output.push(listResult.html);
+            i = listResult.endIndex + 1;
+            continue;
+        }
+
+        // Check for horizontal rule
+        if (/^[-*_]{3,}$/.test(line.trim())) {
+            output.push('<hr class="my-4 border-dark-300 dark:border-dark-600">');
+            i++;
+            continue;
+        }
+
+        // Check for blockquote
+        if (line.startsWith("> ")) {
+            const quoteLines: string[] = [];
+            while (i < lines.length && lines[i].startsWith("> ")) {
+                quoteLines.push(lines[i].slice(2));
+                i++;
+            }
+            const quoteContent = quoteLines.map((l) => processInlineMarkdown(l)).join("<br>");
+            output.push(
+                `<blockquote class="border-l-4 border-dark-300 dark:border-dark-600 pl-4 my-2 italic text-dark-600 dark:text-dark-400">${quoteContent}</blockquote>`,
+            );
+            continue;
+        }
+
+        // Empty line (paragraph break)
+        if (line.trim() === "") {
+            i++;
+            continue;
+        }
+
+        // Regular paragraph - collect consecutive non-special lines
+        const paragraphLines: string[] = [];
+        while (
+            i < lines.length &&
+            lines[i].trim() !== "" &&
+            !lines[i].startsWith("```") &&
+            !isHeader(lines[i]) &&
+            !isListItem(lines[i]) &&
+            !lines[i].startsWith("> ") &&
+            !/^[-*_]{3,}$/.test(lines[i].trim())
+        ) {
+            paragraphLines.push(lines[i]);
+            i++;
+        }
+
+        if (paragraphLines.length > 0) {
+            const content = paragraphLines.map((l) => processInlineMarkdown(l)).join("<br>");
+            output.push(`<p class="my-1">${content}</p>`);
+        }
+    }
+
+    return output.join("");
+}
+
+/**
+ * Checks if a string contains any markdown syntax.
+ * Useful for deciding whether to render as markdown or plain text.
+ */
+export function containsMarkdown(text: string): boolean {
+    // Check for common markdown patterns
+    const patterns = [
+        /\*\*[^*]+\*\*/, // Bold
+        /\*[^*]+\*/, // Italic
+        /__[^_]+__/, // Bold underscore
+        /_[^_]+_/, // Italic underscore
+        /`[^`]+`/, // Inline code
+        /```/, // Code block
+        /^#{1,6}\s/m, // Header
+        /^[-*+]\s/m, // Unordered list
+        /^\d+\.\s/m, // Ordered list
+        /\[[^\]]+\]\([^)]+\)/, // Link
+    ];
+
+    return patterns.some((pattern) => pattern.test(text));
+}

--- a/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
+++ b/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
@@ -148,7 +148,8 @@
                             <div class="max-w-[85%] rounded-lg px-4 py-2 bg-primary-100 dark:bg-primary-900/30 text-dark-900 dark:text-dark-100 text-sm">{{ turn.instruction }}</div>
                         </div>
                         <div class="flex justify-start">
-                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-dark-100 dark:bg-dark-700/50 text-dark-800 dark:text-dark-200 text-sm whitespace-pre-wrap {{ turn.status == 'failed' ? 'border-l-2 border-red-500 pl-2' : '' }}">{{ turn.response ?: '(No response)' }}</div>
+                            <div class="max-w-[85%] rounded-lg px-4 py-2 bg-dark-100 dark:bg-dark-700/50 text-dark-800 dark:text-dark-200 text-sm {{ turn.status == 'failed' ? 'border-l-2 border-red-500 pl-2' : '' }}"
+                                 {{ stimulus_controller('markdown', { streaming: false }) }}>{{ turn.response ?: '(No response)' }}</div>
                         </div>
                     {% endfor %}
                 {% endif %}

--- a/tests/frontend/unit/ChatBasedContentEditor/markdown_renderer.test.ts
+++ b/tests/frontend/unit/ChatBasedContentEditor/markdown_renderer.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect } from "vitest";
+import {
+    renderMarkdown,
+    escapeHtmlForMarkdown,
+    containsMarkdown,
+} from "../../../../src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/markdown_renderer.ts";
+
+describe("markdown_renderer", () => {
+    describe("escapeHtmlForMarkdown", () => {
+        it("should escape HTML special characters", () => {
+            expect(escapeHtmlForMarkdown("<script>alert('xss')</script>")).toBe(
+                "&lt;script&gt;alert(&#039;xss&#039;)&lt;/script&gt;",
+            );
+        });
+
+        it("should escape ampersands", () => {
+            expect(escapeHtmlForMarkdown("foo & bar")).toBe("foo &amp; bar");
+        });
+
+        it("should escape quotes", () => {
+            expect(escapeHtmlForMarkdown('say "hello"')).toBe("say &quot;hello&quot;");
+        });
+
+        it("should handle empty string", () => {
+            expect(escapeHtmlForMarkdown("")).toBe("");
+        });
+
+        it("should preserve normal text", () => {
+            expect(escapeHtmlForMarkdown("Hello, world!")).toBe("Hello, world!");
+        });
+    });
+
+    describe("renderMarkdown", () => {
+        describe("basic text", () => {
+            it("should render plain text in a paragraph", () => {
+                const result = renderMarkdown("Hello, world!");
+                expect(result).toContain("<p");
+                expect(result).toContain("Hello, world!");
+                expect(result).toContain("</p>");
+            });
+
+            it("should handle empty string", () => {
+                expect(renderMarkdown("")).toBe("");
+            });
+
+            it("should escape HTML in plain text", () => {
+                const result = renderMarkdown("<script>alert('xss')</script>");
+                expect(result).not.toContain("<script>");
+                expect(result).toContain("&lt;script&gt;");
+            });
+        });
+
+        describe("bold text", () => {
+            it("should render **text** as bold", () => {
+                const result = renderMarkdown("This is **bold** text");
+                expect(result).toContain("<strong>bold</strong>");
+            });
+
+            it("should render __text__ as bold", () => {
+                const result = renderMarkdown("This is __bold__ text");
+                expect(result).toContain("<strong>bold</strong>");
+            });
+
+            it("should handle multiple bold sections", () => {
+                const result = renderMarkdown("**one** and **two**");
+                expect(result).toContain("<strong>one</strong>");
+                expect(result).toContain("<strong>two</strong>");
+            });
+        });
+
+        describe("italic text", () => {
+            it("should render *text* as italic", () => {
+                const result = renderMarkdown("This is *italic* text");
+                expect(result).toContain("<em>italic</em>");
+            });
+
+            it("should render _text_ as italic", () => {
+                const result = renderMarkdown("This is _italic_ text");
+                expect(result).toContain("<em>italic</em>");
+            });
+
+            it("should not render underscores inside words as italic", () => {
+                const result = renderMarkdown("snake_case_variable");
+                expect(result).not.toContain("<em>");
+            });
+        });
+
+        describe("inline code", () => {
+            it("should render `code` with code styling", () => {
+                const result = renderMarkdown("Use `console.log()` for debugging");
+                expect(result).toContain("<code");
+                expect(result).toContain("console.log()");
+                expect(result).toContain("</code>");
+            });
+
+            it("should escape HTML inside inline code", () => {
+                const result = renderMarkdown("Use `<div>` element");
+                expect(result).toContain("&lt;div&gt;");
+            });
+
+            it("should not process markdown inside inline code", () => {
+                const result = renderMarkdown("Use `**not bold**` here");
+                expect(result).toContain("**not bold**");
+                expect(result).not.toContain("<strong>");
+            });
+        });
+
+        describe("code blocks", () => {
+            it("should render fenced code blocks", () => {
+                const markdown = "```\nconst x = 1;\n```";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<pre");
+                expect(result).toContain("<code");
+                expect(result).toContain("const x = 1;");
+                expect(result).toContain("</code>");
+                expect(result).toContain("</pre>");
+            });
+
+            it("should include language class when specified", () => {
+                const markdown = "```javascript\nconst x = 1;\n```";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain('class="language-javascript"');
+            });
+
+            it("should escape HTML inside code blocks", () => {
+                const markdown = "```\n<script>alert('xss')</script>\n```";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("&lt;script&gt;");
+                expect(result).not.toContain("<script>");
+            });
+
+            it("should preserve whitespace in code blocks", () => {
+                const markdown = "```\n  indented\n    more indented\n```";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("  indented");
+                expect(result).toContain("    more indented");
+            });
+
+            it("should handle multiline code blocks", () => {
+                const markdown = "```typescript\ninterface User {\n  name: string;\n  age: number;\n}\n```";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("interface User {");
+                expect(result).toContain("name: string;");
+            });
+        });
+
+        describe("headers", () => {
+            it("should render h1 headers", () => {
+                const result = renderMarkdown("# Header 1");
+                expect(result).toContain("<h1");
+                expect(result).toContain("Header 1");
+                expect(result).toContain("</h1>");
+            });
+
+            it("should render h2 headers", () => {
+                const result = renderMarkdown("## Header 2");
+                expect(result).toContain("<h2");
+                expect(result).toContain("Header 2");
+            });
+
+            it("should render h3-h6 headers", () => {
+                expect(renderMarkdown("### Header")).toContain("<h3");
+                expect(renderMarkdown("#### Header")).toContain("<h4");
+                expect(renderMarkdown("##### Header")).toContain("<h5");
+                expect(renderMarkdown("###### Header")).toContain("<h6");
+            });
+
+            it("should process inline markdown in headers", () => {
+                const result = renderMarkdown("# **Bold** Header");
+                expect(result).toContain("<h1");
+                expect(result).toContain("<strong>Bold</strong>");
+            });
+        });
+
+        describe("unordered lists", () => {
+            it("should render dash lists", () => {
+                const markdown = "- Item 1\n- Item 2\n- Item 3";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<ul");
+                expect(result).toContain("<li>Item 1</li>");
+                expect(result).toContain("<li>Item 2</li>");
+                expect(result).toContain("<li>Item 3</li>");
+                expect(result).toContain("</ul>");
+            });
+
+            it("should render asterisk lists", () => {
+                const markdown = "* Item 1\n* Item 2";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<ul");
+                expect(result).toContain("<li>Item 1</li>");
+            });
+
+            it("should render plus sign lists", () => {
+                const markdown = "+ Item 1\n+ Item 2";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<ul");
+                expect(result).toContain("<li>Item 1</li>");
+            });
+
+            it("should process inline markdown in list items", () => {
+                const markdown = "- **Bold** item\n- *Italic* item";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<strong>Bold</strong>");
+                expect(result).toContain("<em>Italic</em>");
+            });
+        });
+
+        describe("ordered lists", () => {
+            it("should render numbered lists", () => {
+                const markdown = "1. First\n2. Second\n3. Third";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<ol");
+                expect(result).toContain("<li>First</li>");
+                expect(result).toContain("<li>Second</li>");
+                expect(result).toContain("<li>Third</li>");
+                expect(result).toContain("</ol>");
+            });
+
+            it("should process inline markdown in ordered list items", () => {
+                const markdown = "1. **Bold** item\n2. `code` item";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<strong>Bold</strong>");
+                expect(result).toContain("<code");
+            });
+        });
+
+        describe("links", () => {
+            it("should render markdown links", () => {
+                const result = renderMarkdown("[Click here](https://example.com)");
+                expect(result).toContain("<a");
+                expect(result).toContain('href="https://example.com"');
+                expect(result).toContain("Click here");
+                expect(result).toContain("</a>");
+            });
+
+            it("should add target blank and noopener", () => {
+                const result = renderMarkdown("[Link](https://example.com)");
+                expect(result).toContain('target="_blank"');
+                expect(result).toContain('rel="noopener noreferrer"');
+            });
+
+            it("should sanitize javascript: URLs", () => {
+                const result = renderMarkdown("[Click](javascript:alert('xss'))");
+                expect(result).toContain('href="#"');
+                expect(result).not.toContain("javascript:");
+            });
+
+            it("should sanitize data: URLs", () => {
+                const result = renderMarkdown("[Click](data:text/html,<script>alert('xss')</script>)");
+                expect(result).toContain('href="#"');
+                expect(result).not.toContain("data:");
+            });
+        });
+
+        describe("blockquotes", () => {
+            it("should render blockquotes", () => {
+                const result = renderMarkdown("> This is a quote");
+                expect(result).toContain("<blockquote");
+                expect(result).toContain("This is a quote");
+                expect(result).toContain("</blockquote>");
+            });
+
+            it("should handle multiline blockquotes", () => {
+                const markdown = "> Line 1\n> Line 2";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("Line 1");
+                expect(result).toContain("Line 2");
+            });
+        });
+
+        describe("horizontal rules", () => {
+            it("should render --- as horizontal rule", () => {
+                const result = renderMarkdown("---");
+                expect(result).toContain("<hr");
+            });
+
+            it("should render *** as horizontal rule", () => {
+                const result = renderMarkdown("***");
+                expect(result).toContain("<hr");
+            });
+
+            it("should render ___ as horizontal rule", () => {
+                const result = renderMarkdown("___");
+                expect(result).toContain("<hr");
+            });
+        });
+
+        describe("paragraphs and line breaks", () => {
+            it("should create separate paragraphs for text separated by blank lines", () => {
+                const markdown = "Paragraph 1\n\nParagraph 2";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("Paragraph 1");
+                expect(result).toContain("Paragraph 2");
+                // Both should be in separate paragraph tags
+                const pCount = (result.match(/<p/g) || []).length;
+                expect(pCount).toBe(2);
+            });
+
+            it("should create line breaks for consecutive lines", () => {
+                const markdown = "Line 1\nLine 2\nLine 3";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("Line 1<br>Line 2<br>Line 3");
+            });
+        });
+
+        describe("complex markdown", () => {
+            it("should handle combined formatting", () => {
+                const markdown = "**bold and *italic* together**";
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<strong>");
+                expect(result).toContain("<em>");
+            });
+
+            it("should handle mixed content", () => {
+                const markdown = `# Title
+
+This is a paragraph with **bold** and *italic*.
+
+- List item 1
+- List item 2
+
+\`\`\`javascript
+const x = 1;
+\`\`\`
+
+> A quote`;
+                const result = renderMarkdown(markdown);
+                expect(result).toContain("<h1");
+                expect(result).toContain("<strong>bold</strong>");
+                expect(result).toContain("<em>italic</em>");
+                expect(result).toContain("<ul");
+                expect(result).toContain("<pre");
+                expect(result).toContain("<blockquote");
+            });
+        });
+
+        describe("streaming mode", () => {
+            it("should handle unclosed code blocks in streaming mode", () => {
+                const markdown = "```javascript\nconst x = 1;";
+                const result = renderMarkdown(markdown, { streaming: true });
+                // Should still render as code block even without closing fence
+                expect(result).toContain("<pre");
+                expect(result).toContain("const x = 1;");
+            });
+
+            it("should handle partial markdown gracefully", () => {
+                const markdown = "This is **bo";
+                const result = renderMarkdown(markdown, { streaming: true });
+                // Should not crash, render as-is
+                expect(result).toContain("**bo");
+            });
+        });
+
+        describe("XSS prevention", () => {
+            it("should escape HTML in all contexts", () => {
+                const malicious = `<img src="x" onerror="alert('xss')">`;
+                const result = renderMarkdown(malicious);
+                // The <img tag should be escaped, not rendered as an actual element
+                expect(result).not.toContain("<img");
+                expect(result).toContain("&lt;img");
+            });
+
+            it("should escape script tags", () => {
+                const result = renderMarkdown("<script>alert('xss')</script>");
+                expect(result).not.toContain("<script>");
+            });
+
+            it("should escape HTML in headers", () => {
+                const result = renderMarkdown("# <script>alert('xss')</script>");
+                expect(result).not.toContain("<script>");
+            });
+
+            it("should escape HTML in list items", () => {
+                const result = renderMarkdown("- <img src=x onerror=alert('xss')>");
+                expect(result).not.toContain("<img");
+            });
+        });
+    });
+
+    describe("containsMarkdown", () => {
+        it("should detect bold markers", () => {
+            expect(containsMarkdown("This is **bold**")).toBe(true);
+            expect(containsMarkdown("This is __bold__")).toBe(true);
+        });
+
+        it("should detect italic markers", () => {
+            expect(containsMarkdown("This is *italic*")).toBe(true);
+            expect(containsMarkdown("This is _italic_")).toBe(true);
+        });
+
+        it("should detect code markers", () => {
+            expect(containsMarkdown("Use `code` here")).toBe(true);
+            expect(containsMarkdown("```\ncode block\n```")).toBe(true);
+        });
+
+        it("should detect headers", () => {
+            expect(containsMarkdown("# Header")).toBe(true);
+            expect(containsMarkdown("## Header")).toBe(true);
+        });
+
+        it("should detect lists", () => {
+            expect(containsMarkdown("- item")).toBe(true);
+            expect(containsMarkdown("* item")).toBe(true);
+            expect(containsMarkdown("1. item")).toBe(true);
+        });
+
+        it("should detect links", () => {
+            expect(containsMarkdown("[text](url)")).toBe(true);
+        });
+
+        it("should return false for plain text", () => {
+            expect(containsMarkdown("This is plain text")).toBe(false);
+            expect(containsMarkdown("Hello, world!")).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Implement markdown rendering for agent responses in the chat editor,
supporting streaming content that arrives incrementally.

- Add markdown_renderer.ts with lightweight parser (bold, italic, code,
  headers, lists, links, blockquotes) and XSS prevention
- Add markdown Stimulus controller for reusable rendering
- Update chat editor to render streamed text as markdown
- Add 58 unit tests for markdown rendering