### PR TITLE
fix(chat): resolve race condition breaking technical containers on page reload

### DIFF
--- a/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/chat_based_content_editor_controller.ts
+++ b/src/ChatBasedContentEditor/Presentation/Resources/assets/controllers/chat_based_content_editor_controller.ts
@@ -362,11 +362,6 @@ export default class extends Controller {
         const turnsToProcess = hasActiveSession ? turns.slice(0, -1) : turns;
 
         turnsToProcess.forEach((turn, index) => {
-            // Only render if there are events to show
-            if (!turn.events || turn.events.length === 0) {
-                return;
-            }
-
             const assistantEl = assistantElements[index];
             if (!assistantEl) {
                 return;
@@ -378,20 +373,27 @@ export default class extends Controller {
                 return;
             }
 
-            // Create a wrapper for the technical container and response
-            const existingContent = innerContainer.innerHTML;
+            // Clear the container and set up structure
             innerContainer.innerHTML = "";
             innerContainer.classList.add("space-y-2");
 
-            // Create and add completed technical container
-            const technicalContainer = this.createCompletedTechnicalContainer(turn);
-            innerContainer.appendChild(technicalContainer);
+            // Create and add completed technical container if there are events
+            if (turn.events && turn.events.length > 0) {
+                const technicalContainer = this.createCompletedTechnicalContainer(turn);
+                innerContainer.appendChild(technicalContainer);
+            }
 
-            // Add back the response text
-            if (existingContent) {
+            // Render the response text as markdown
+            const responseText = turn.response || innerContainer.dataset.turnResponse || "";
+            if (responseText) {
                 const textEl = document.createElement("div");
                 textEl.className = "whitespace-pre-wrap";
-                textEl.innerHTML = existingContent;
+                textEl.innerHTML = renderMarkdown(responseText, { streaming: false });
+                innerContainer.appendChild(textEl);
+            } else {
+                const textEl = document.createElement("div");
+                textEl.className = "whitespace-pre-wrap text-dark-500 dark:text-dark-400";
+                textEl.textContent = "(No response)";
                 innerContainer.appendChild(textEl);
             }
         });

--- a/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
+++ b/src/ChatBasedContentEditor/Presentation/Resources/templates/chat_based_content_editor.twig
@@ -148,8 +148,10 @@
                             <div class="max-w-[85%] rounded-lg px-4 py-2 bg-primary-100 dark:bg-primary-900/30 text-dark-900 dark:text-dark-100 text-sm">{{ turn.instruction }}</div>
                         </div>
                         <div class="flex justify-start">
+                            {# Note: Markdown rendering is handled by chat_based_content_editor_controller.ts #}
+                            {# to avoid race conditions with technical container rendering #}
                             <div class="max-w-[85%] rounded-lg px-4 py-2 bg-dark-100 dark:bg-dark-700/50 text-dark-800 dark:text-dark-200 text-sm {{ turn.status == 'failed' ? 'border-l-2 border-red-500 pl-2' : '' }}"
-                                 {{ stimulus_controller('markdown', { streaming: false }) }}>{{ turn.response ?: '(No response)' }}</div>
+                                 data-turn-response="{{ turn.response ?: '' }}"></div>
                         </div>
                     {% endfor %}
                 {% endif %}


### PR DESCRIPTION
Remove markdown controller from server-rendered assistant responses to fix a race condition with renderCompletedTurnsTechnicalContainers(). When the markdown controller ran after the technical container was created, it would overwrite the entire innerHTML, destroying the container structure.

Now the chat-based-content-editor controller handles both technical container creation and markdown rendering for completed turns, eliminating the race.