### PR TITLE
Add per-project agent configuration with project-type templates

### DIFF
--- a/migrations/Version20260125100259.php
+++ b/migrations/Version20260125100259.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add per-project agent configuration fields to projects table.
+ */
+final class Version20260125100259 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add agent configuration fields (background, step, output instructions) to projects table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE projects ADD agent_background_instructions LONGTEXT NOT NULL, ADD agent_step_instructions LONGTEXT NOT NULL, ADD agent_output_instructions LONGTEXT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE projects DROP agent_background_instructions, DROP agent_step_instructions, DROP agent_output_instructions');
+    }
+}

--- a/src/ChatBasedContentEditor/Infrastructure/Handler/RunEditSessionHandler.php
+++ b/src/ChatBasedContentEditor/Infrastructure/Handler/RunEditSessionHandler.php
@@ -13,6 +13,7 @@ use App\ChatBasedContentEditor\Domain\Enum\ConversationMessageRole;
 use App\ChatBasedContentEditor\Domain\Enum\EditSessionStatus;
 use App\ChatBasedContentEditor\Infrastructure\Message\RunEditSessionMessage;
 use App\ChatBasedContentEditor\Infrastructure\Service\ConversationUrlServiceInterface;
+use App\LlmContentEditor\Facade\Dto\AgentConfigDto;
 use App\LlmContentEditor\Facade\Dto\AgentEventDto;
 use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
 use App\LlmContentEditor\Facade\Dto\ToolInputEntryDto;
@@ -89,11 +90,19 @@ final readonly class RunEditSessionHandler
                 $project->agentImage
             );
 
+            // Build agent configuration from project settings
+            $agentConfig = new AgentConfigDto(
+                $project->agentBackgroundInstructions,
+                $project->agentStepInstructions,
+                $project->agentOutputInstructions,
+            );
+
             $generator = $this->facade->streamEditWithHistory(
                 $session->getWorkspacePath(),
                 $session->getInstruction(),
                 $previousMessages,
-                $project->llmApiKey
+                $project->llmApiKey,
+                $agentConfig
             );
 
             foreach ($generator as $chunk) {

--- a/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
+++ b/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\LlmContentEditor\Domain\Agent;
 
 use App\LlmContentEditor\Domain\Enum\LlmModelName;
+use App\LlmContentEditor\Facade\Dto\AgentConfigDto;
 use App\WorkspaceTooling\Facade\WorkspaceToolingServiceInterface;
 use EtfsCodingAgent\Agent\BaseCodingAgent;
 use NeuronAI\Providers\AIProviderInterface;
@@ -19,6 +20,7 @@ class ContentEditorAgent extends BaseCodingAgent
         private readonly WorkspaceToolingServiceInterface $sitebuilderFacade,
         private readonly LlmModelName                     $model,
         private readonly string                           $apiKey,
+        private readonly ?AgentConfigDto                  $agentConfig = null,
     ) {
         parent::__construct($sitebuilderFacade);
     }
@@ -35,6 +37,52 @@ class ContentEditorAgent extends BaseCodingAgent
      * @return list<string>
      */
     protected function getBackgroundInstructions(): array
+    {
+        if ($this->agentConfig !== null) {
+            return $this->splitInstructions($this->agentConfig->backgroundInstructions);
+        }
+
+        return $this->getDefaultBackgroundInstructions();
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function getStepInstructions(): array
+    {
+        if ($this->agentConfig !== null) {
+            return $this->splitInstructions($this->agentConfig->stepInstructions);
+        }
+
+        return $this->getDefaultStepInstructions();
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function getOutputInstructions(): array
+    {
+        if ($this->agentConfig !== null) {
+            return $this->splitInstructions($this->agentConfig->outputInstructions);
+        }
+
+        return $this->getDefaultOutputInstructions();
+    }
+
+    /**
+     * Split instruction text into lines.
+     *
+     * @return list<string>
+     */
+    private function splitInstructions(string $instructions): array
+    {
+        return explode("\n", $instructions);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getDefaultBackgroundInstructions(): array
     {
         return [
             'You are a friendly AI Agent that helps the user to work with files in a Node.js web content workspace.',
@@ -84,7 +132,7 @@ class ContentEditorAgent extends BaseCodingAgent
     /**
      * @return list<string>
      */
-    protected function getStepInstructions(): array
+    private function getDefaultStepInstructions(): array
     {
         return [
             '1. EXPLORE: List the working folder (the path from the user\'s message) to understand its structure.',
@@ -101,7 +149,7 @@ class ContentEditorAgent extends BaseCodingAgent
     /**
      * @return list<string>
      */
-    protected function getOutputInstructions(): array
+    private function getDefaultOutputInstructions(): array
     {
         return [
             'Summarize what changes were made and why.',

--- a/src/LlmContentEditor/Facade/Dto/AgentConfigDto.php
+++ b/src/LlmContentEditor/Facade/Dto/AgentConfigDto.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\LlmContentEditor\Facade\Dto;
+
+/**
+ * DTO for passing agent configuration to the LLM content editor.
+ * Contains the three instruction sets that define agent behavior.
+ */
+final readonly class AgentConfigDto
+{
+    public function __construct(
+        public string $backgroundInstructions,
+        public string $stepInstructions,
+        public string $outputInstructions,
+    ) {
+    }
+}

--- a/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
+++ b/src/LlmContentEditor/Facade/LlmContentEditorFacade.php
@@ -6,6 +6,7 @@ namespace App\LlmContentEditor\Facade;
 
 use App\LlmContentEditor\Domain\Agent\ContentEditorAgent;
 use App\LlmContentEditor\Domain\Enum\LlmModelName;
+use App\LlmContentEditor\Facade\Dto\AgentConfigDto;
 use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
 use App\LlmContentEditor\Facade\Dto\EditStreamChunkDto;
 use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
@@ -57,10 +58,11 @@ final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
      * @return Generator<EditStreamChunkDto>
      */
     public function streamEditWithHistory(
-        string $workspacePath,
-        string $instruction,
-        array  $previousMessages,
-        string $llmApiKey
+        string          $workspacePath,
+        string          $instruction,
+        array           $previousMessages,
+        string          $llmApiKey,
+        ?AgentConfigDto $agentConfig = null
     ): Generator {
         // Convert previous message DTOs to NeuronAI messages
         $initialMessages = [];
@@ -123,7 +125,8 @@ final class LlmContentEditorFacade implements LlmContentEditorFacadeInterface
         $agent = new ContentEditorAgent(
             $this->workspaceTooling,
             LlmModelName::defaultForContentEditor(),
-            $llmApiKey
+            $llmApiKey,
+            $agentConfig
         );
         $agent->withChatHistory($chatHistory);
 

--- a/src/LlmContentEditor/Facade/LlmContentEditorFacadeInterface.php
+++ b/src/LlmContentEditor/Facade/LlmContentEditorFacadeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\LlmContentEditor\Facade;
 
+use App\LlmContentEditor\Facade\Dto\AgentConfigDto;
 use App\LlmContentEditor\Facade\Dto\ConversationMessageDto;
 use App\LlmContentEditor\Facade\Dto\EditStreamChunkDto;
 use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
@@ -28,14 +29,16 @@ interface LlmContentEditorFacadeInterface
      *
      * @param list<ConversationMessageDto> $previousMessages Messages from earlier turns in this conversation
      * @param string                       $llmApiKey        The API key for the LLM provider (BYOK)
+     * @param AgentConfigDto|null          $agentConfig      Custom agent configuration, or null for defaults
      *
      * @return Generator<EditStreamChunkDto>
      */
     public function streamEditWithHistory(
-        string $workspacePath,
-        string $instruction,
-        array  $previousMessages,
-        string $llmApiKey
+        string          $workspacePath,
+        string          $instruction,
+        array           $previousMessages,
+        string          $llmApiKey,
+        ?AgentConfigDto $agentConfig = null
     ): Generator;
 
     /**

--- a/src/ProjectMgmt/Domain/Entity/Project.php
+++ b/src/ProjectMgmt/Domain/Entity/Project.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\ProjectMgmt\Domain\Entity;
 
 use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Domain\ValueObject\AgentConfigTemplate;
 use App\ProjectMgmt\Facade\Enum\ProjectType;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +30,10 @@ class Project
         LlmModelProvider $llmModelProvider,
         string           $llmApiKey,
         ProjectType      $projectType = ProjectType::DEFAULT,
-        string           $agentImage = self::DEFAULT_AGENT_IMAGE
+        string           $agentImage = self::DEFAULT_AGENT_IMAGE,
+        ?string          $agentBackgroundInstructions = null,
+        ?string          $agentStepInstructions = null,
+        ?string          $agentOutputInstructions = null
     ) {
         $this->name             = $name;
         $this->gitUrl           = $gitUrl;
@@ -39,6 +43,12 @@ class Project
         $this->projectType      = $projectType;
         $this->agentImage       = $agentImage;
         $this->createdAt        = DateAndTimeService::getDateTimeImmutable();
+
+        // Initialize agent config from template if not provided
+        $template                          = AgentConfigTemplate::forProjectType($projectType);
+        $this->agentBackgroundInstructions = $agentBackgroundInstructions ?? $template->backgroundInstructions;
+        $this->agentStepInstructions       = $agentStepInstructions       ?? $template->stepInstructions;
+        $this->agentOutputInstructions     = $agentOutputInstructions     ?? $template->outputInstructions;
     }
 
     #[ORM\Id]
@@ -175,6 +185,54 @@ class Project
     public function setLlmApiKey(string $llmApiKey): void
     {
         $this->llmApiKey = $llmApiKey;
+    }
+
+    #[ORM\Column(
+        type: Types::TEXT,
+        nullable: false
+    )]
+    private string $agentBackgroundInstructions;
+
+    public function getAgentBackgroundInstructions(): string
+    {
+        return $this->agentBackgroundInstructions;
+    }
+
+    public function setAgentBackgroundInstructions(string $agentBackgroundInstructions): void
+    {
+        $this->agentBackgroundInstructions = $agentBackgroundInstructions;
+    }
+
+    #[ORM\Column(
+        type: Types::TEXT,
+        nullable: false
+    )]
+    private string $agentStepInstructions;
+
+    public function getAgentStepInstructions(): string
+    {
+        return $this->agentStepInstructions;
+    }
+
+    public function setAgentStepInstructions(string $agentStepInstructions): void
+    {
+        $this->agentStepInstructions = $agentStepInstructions;
+    }
+
+    #[ORM\Column(
+        type: Types::TEXT,
+        nullable: false
+    )]
+    private string $agentOutputInstructions;
+
+    public function getAgentOutputInstructions(): string
+    {
+        return $this->agentOutputInstructions;
+    }
+
+    public function setAgentOutputInstructions(string $agentOutputInstructions): void
+    {
+        $this->agentOutputInstructions = $agentOutputInstructions;
     }
 
     #[ORM\Column(

--- a/src/ProjectMgmt/Domain/Service/ProjectService.php
+++ b/src/ProjectMgmt/Domain/Service/ProjectService.php
@@ -27,7 +27,10 @@ final class ProjectService
         LlmModelProvider $llmModelProvider,
         string           $llmApiKey,
         ProjectType      $projectType = ProjectType::DEFAULT,
-        string           $agentImage = Project::DEFAULT_AGENT_IMAGE
+        string           $agentImage = Project::DEFAULT_AGENT_IMAGE,
+        ?string          $agentBackgroundInstructions = null,
+        ?string          $agentStepInstructions = null,
+        ?string          $agentOutputInstructions = null
     ): Project {
         $project = new Project(
             $name,
@@ -36,7 +39,10 @@ final class ProjectService
             $llmModelProvider,
             $llmApiKey,
             $projectType,
-            $agentImage
+            $agentImage,
+            $agentBackgroundInstructions,
+            $agentStepInstructions,
+            $agentOutputInstructions
         );
         $this->entityManager->persist($project);
         $this->entityManager->flush();
@@ -52,7 +58,10 @@ final class ProjectService
         LlmModelProvider $llmModelProvider,
         string           $llmApiKey,
         ProjectType      $projectType = ProjectType::DEFAULT,
-        string           $agentImage = Project::DEFAULT_AGENT_IMAGE
+        string           $agentImage = Project::DEFAULT_AGENT_IMAGE,
+        ?string          $agentBackgroundInstructions = null,
+        ?string          $agentStepInstructions = null,
+        ?string          $agentOutputInstructions = null
     ): void {
         $project->setName($name);
         $project->setGitUrl($gitUrl);
@@ -61,6 +70,17 @@ final class ProjectService
         $project->setLlmApiKey($llmApiKey);
         $project->setProjectType($projectType);
         $project->setAgentImage($agentImage);
+
+        if ($agentBackgroundInstructions !== null) {
+            $project->setAgentBackgroundInstructions($agentBackgroundInstructions);
+        }
+        if ($agentStepInstructions !== null) {
+            $project->setAgentStepInstructions($agentStepInstructions);
+        }
+        if ($agentOutputInstructions !== null) {
+            $project->setAgentOutputInstructions($agentOutputInstructions);
+        }
+
         $this->entityManager->flush();
     }
 

--- a/src/ProjectMgmt/Domain/ValueObject/AgentConfigTemplate.php
+++ b/src/ProjectMgmt/Domain/ValueObject/AgentConfigTemplate.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Domain\ValueObject;
+
+use App\ProjectMgmt\Facade\Enum\ProjectType;
+
+/**
+ * Provides default agent configuration templates for each project type.
+ * These templates are copied to the project during creation and can be customized per-project.
+ */
+final readonly class AgentConfigTemplate
+{
+    private function __construct(
+        public string $backgroundInstructions,
+        public string $stepInstructions,
+        public string $outputInstructions,
+    ) {
+    }
+
+    public static function forProjectType(ProjectType $type): self
+    {
+        return match ($type) {
+            ProjectType::DEFAULT => self::defaultTemplate(),
+        };
+    }
+
+    private static function defaultTemplate(): self
+    {
+        $backgroundInstructions = <<<'INSTRUCTIONS'
+You are a friendly AI Agent that helps the user to work with files in a Node.js web content workspace.
+You have access to tools for exploring folders, reading files, applying edits, and running workspace commands.
+
+WORKSPACE CONVENTIONS:
+- All workspaces are Node.js projects with package.json at the root
+- Source files are in src/ (HTML pages, TypeScript/JavaScript, CSS, assets)
+- The Living Styleguide, which is the reference for look and feel of all content pages, is at src/styleguide/index.html and src/styles/main.css.
+- Tests are typically in tests/ or src/__tests__/
+- Build output goes to dist/ or build/ (generated, do not edit directly)
+- README.md contains project documentation and instructions
+
+PATH RULES (critical):
+- The working folder path is given in the user's message. Use it for ALL path-based tools (get_folder_content, get_file_content, get_file_lines, replace_in_file, apply_diff_to_file, run_quality_checks, run_tests, run_build).
+- "Workspace root" and "working folder" are the same. Both mean the path from the user's message.
+- Never use /workspace or any path not under the working folder.
+- If a tool returns "Directory does not exist" or "File does not exist", the path you used is wrong. Do not retry the same path. Re-read the user's message for the correct working folder and use paths under it.
+
+EFFICIENT FILE READING:
+- Use get_file_info first to check file size before reading
+- For large files (>100 lines), use search_in_file to find relevant sections
+- Use get_file_lines to read only the lines you need
+- Only use get_file_content for small files or when you need the entire content
+
+EFFICIENT FILE EDITING:
+- Use replace_in_file for simple, targeted edits (preferred for single changes)
+- The old_string must be unique - include surrounding context if needed
+- Use apply_diff_to_file only for complex multi-location edits
+- Always search or read the relevant section before editing to ensure accuracy
+
+DISCOVERY IS KEY:
+- Always explore the workspace structure before making changes
+- Read package.json to understand available scripts and dependencies
+- Read README.md to understand project conventions and workflows
+- Look for styleguides, examples, or documentation in the workspace
+- Examine existing files to understand patterns before creating new ones
+
+WORK SCOPE:
+- Modify existing pages, remove existing pages, create new pages, as the user wishes
+- If specifically requested, modify the styleguide, too
+- Look out for reasons to modify the styleguide even without being explicitly asked to, if content changes that the users asks for make it make sense to adapt the styleguide accordingly
+- Every content modification must be in line with the styleguide, unless the user explicitly asks for a one-off solution
+INSTRUCTIONS;
+
+        $stepInstructions = <<<'INSTRUCTIONS'
+1. EXPLORE: List the working folder (the path from the user's message) to understand its structure.
+2. UNDERSTAND: Read package.json and README.md to learn about the project.
+3. INVESTIGATE: Use get_file_info + search_in_file to efficiently explore files.
+4. PLAN: Understand what files need to be created or modified.
+5. EDIT: Use replace_in_file for targeted edits, apply_diff_to_file for complex changes.
+6. VERIFY: Run run_quality_checks to ensure code standards are met.
+7. TEST: Run run_tests to verify functionality.
+8. BUILD: Run run_build to confirm the project compiles successfully.
+INSTRUCTIONS;
+
+        $outputInstructions = <<<'INSTRUCTIONS'
+Summarize what changes were made and why.
+If quality checks, tests, or build fail, analyze the errors and fix them.
+Always verify your changes with quality checks, tests, and build before finishing.
+INSTRUCTIONS;
+
+        return new self($backgroundInstructions, $stepInstructions, $outputInstructions);
+    }
+}

--- a/src/ProjectMgmt/Facade/Dto/AgentConfigTemplateDto.php
+++ b/src/ProjectMgmt/Facade/Dto/AgentConfigTemplateDto.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Facade\Dto;
+
+/**
+ * DTO for agent configuration template.
+ * Used to expose default templates based on project type.
+ */
+final readonly class AgentConfigTemplateDto
+{
+    public function __construct(
+        public string $backgroundInstructions,
+        public string $stepInstructions,
+        public string $outputInstructions,
+    ) {
+    }
+}

--- a/src/ProjectMgmt/Facade/Dto/ProjectInfoDto.php
+++ b/src/ProjectMgmt/Facade/Dto/ProjectInfoDto.php
@@ -19,6 +19,9 @@ final readonly class ProjectInfoDto
         public string           $agentImage,
         public LlmModelProvider $llmModelProvider,
         public string           $llmApiKey,
+        public string           $agentBackgroundInstructions,
+        public string           $agentStepInstructions,
+        public string           $agentOutputInstructions,
     ) {
     }
 }

--- a/src/ProjectMgmt/Facade/ProjectMgmtFacade.php
+++ b/src/ProjectMgmt/Facade/ProjectMgmtFacade.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\ProjectMgmt\Facade;
 
 use App\ProjectMgmt\Domain\Entity\Project;
+use App\ProjectMgmt\Domain\ValueObject\AgentConfigTemplate;
+use App\ProjectMgmt\Facade\Dto\AgentConfigTemplateDto;
 use App\ProjectMgmt\Facade\Dto\ExistingLlmApiKeyDto;
 use App\ProjectMgmt\Facade\Dto\ProjectInfoDto;
+use App\ProjectMgmt\Facade\Enum\ProjectType;
 use App\WorkspaceMgmt\Infrastructure\Service\GitHubUrlServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
@@ -117,6 +120,20 @@ final class ProjectMgmtFacade implements ProjectMgmtFacadeInterface
             $project->getAgentImage(),
             $project->getLlmModelProvider(),
             $project->getLlmApiKey(),
+            $project->getAgentBackgroundInstructions(),
+            $project->getAgentStepInstructions(),
+            $project->getAgentOutputInstructions(),
+        );
+    }
+
+    public function getAgentConfigTemplate(ProjectType $type): AgentConfigTemplateDto
+    {
+        $template = AgentConfigTemplate::forProjectType($type);
+
+        return new AgentConfigTemplateDto(
+            $template->backgroundInstructions,
+            $template->stepInstructions,
+            $template->outputInstructions,
         );
     }
 

--- a/src/ProjectMgmt/Facade/ProjectMgmtFacadeInterface.php
+++ b/src/ProjectMgmt/Facade/ProjectMgmtFacadeInterface.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\ProjectMgmt\Facade;
 
+use App\ProjectMgmt\Facade\Dto\AgentConfigTemplateDto;
 use App\ProjectMgmt\Facade\Dto\ExistingLlmApiKeyDto;
 use App\ProjectMgmt\Facade\Dto\ProjectInfoDto;
+use App\ProjectMgmt\Facade\Enum\ProjectType;
 
 /**
  * Facade for project management operations.
@@ -33,4 +35,10 @@ interface ProjectMgmtFacadeInterface
      * @return list<ExistingLlmApiKeyDto>
      */
     public function getExistingLlmApiKeys(): array;
+
+    /**
+     * Get the default agent configuration template for a given project type.
+     * Used to pre-fill the agent configuration form during project creation.
+     */
+    public function getAgentConfigTemplate(ProjectType $type): AgentConfigTemplateDto;
 }

--- a/src/ProjectMgmt/Presentation/Resources/templates/project_form.twig
+++ b/src/ProjectMgmt/Presentation/Resources/templates/project_form.twig
@@ -180,6 +180,54 @@
                 });
             </script>
 
+            {# Agent Configuration (Advanced) - collapsible section #}
+            <details class="border border-dark-200 dark:border-dark-700 rounded-lg">
+                <summary class="px-4 py-3 cursor-pointer select-none text-sm font-medium text-dark-700 dark:text-dark-300 hover:bg-dark-50 dark:hover:bg-dark-900/50 rounded-lg">
+                    Agent Configuration (Advanced)
+                </summary>
+                <div class="px-4 pb-4 pt-2 space-y-4 border-t border-dark-200 dark:border-dark-700">
+                    <p class="text-xs text-dark-500 dark:text-dark-400">
+                        Customize how the AI agent behaves when editing this project. These settings control the agent's instructions and workflow.
+                    </p>
+
+                    <div>
+                        <label for="agent_background_instructions" class="etfswui-form-label">Background Instructions</label>
+                        <textarea name="agent_background_instructions"
+                                  id="agent_background_instructions"
+                                  rows="10"
+                                  class="etfswui-form-textarea font-mono text-xs"
+                                  placeholder="System context and workspace conventions...">{{ project ? project.agentBackgroundInstructions : agentConfigTemplate.backgroundInstructions }}</textarea>
+                        <p class="mt-1 text-xs text-dark-500 dark:text-dark-400">
+                            System context about the workspace, conventions, and rules the agent should follow.
+                        </p>
+                    </div>
+
+                    <div>
+                        <label for="agent_step_instructions" class="etfswui-form-label">Step Instructions</label>
+                        <textarea name="agent_step_instructions"
+                                  id="agent_step_instructions"
+                                  rows="6"
+                                  class="etfswui-form-textarea font-mono text-xs"
+                                  placeholder="Workflow steps...">{{ project ? project.agentStepInstructions : agentConfigTemplate.stepInstructions }}</textarea>
+                        <p class="mt-1 text-xs text-dark-500 dark:text-dark-400">
+                            The workflow steps the agent should follow when making changes.
+                        </p>
+                    </div>
+
+                    <div>
+                        <label for="agent_output_instructions" class="etfswui-form-label">Output Instructions</label>
+                        <textarea name="agent_output_instructions"
+                                  id="agent_output_instructions"
+                                  rows="4"
+                                  class="etfswui-form-textarea font-mono text-xs"
+                                  placeholder="Output format instructions...">{{ project ? project.agentOutputInstructions : agentConfigTemplate.outputInstructions }}</textarea>
+                        <p class="mt-1 text-xs text-dark-500 dark:text-dark-400">
+                            Instructions for how the agent should format its output and summaries.
+                        </p>
+                    </div>
+                </div>
+            </details>
+
             <div class="rounded-lg border border-dark-200 dark:border-dark-700 bg-dark-50 dark:bg-dark-800 p-4 text-sm text-dark-600 dark:text-dark-400 space-y-3">
                 <p>
                     Need a GitHub access key? Create a <strong>Personal Access Token</strong> so the app can read and update your project.

--- a/tests/Unit/LlmContentEditor/ContentEditorAgentTest.php
+++ b/tests/Unit/LlmContentEditor/ContentEditorAgentTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\LlmContentEditor;
 
 use App\LlmContentEditor\Domain\Agent\ContentEditorAgent;
 use App\LlmContentEditor\Domain\Enum\LlmModelName;
+use App\LlmContentEditor\Facade\Dto\AgentConfigDto;
 use App\WorkspaceTooling\Facade\WorkspaceToolingServiceInterface;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -50,6 +51,63 @@ final class ContentEditorAgentTest extends TestCase
         self::assertStringContainsString('working folder', $exploreStep);
         self::assertStringContainsString("path from the user's message", $exploreStep);
         self::assertStringNotContainsString('workspace root folder', $exploreStep);
+    }
+
+    public function testAgentUsesCustomConfigWhenProvided(): void
+    {
+        $customConfig = new AgentConfigDto(
+            "Custom background\nwith multiple lines",
+            "Custom step 1\nCustom step 2",
+            'Custom output'
+        );
+
+        $agent = new ContentEditorAgent(
+            $this->createMockWorkspaceTooling(),
+            LlmModelName::defaultForContentEditor(),
+            'sk-test-key',
+            $customConfig
+        );
+
+        $bgRef = new ReflectionMethod(ContentEditorAgent::class, 'getBackgroundInstructions');
+        $bgRef->setAccessible(true);
+        /** @var list<string> $bgInstructions */
+        $bgInstructions = $bgRef->invoke($agent);
+
+        self::assertSame(['Custom background', 'with multiple lines'], $bgInstructions);
+
+        $stepRef = new ReflectionMethod(ContentEditorAgent::class, 'getStepInstructions');
+        $stepRef->setAccessible(true);
+        /** @var list<string> $stepInstructions */
+        $stepInstructions = $stepRef->invoke($agent);
+
+        self::assertSame(['Custom step 1', 'Custom step 2'], $stepInstructions);
+
+        $outputRef = new ReflectionMethod(ContentEditorAgent::class, 'getOutputInstructions');
+        $outputRef->setAccessible(true);
+        /** @var list<string> $outputInstructions */
+        $outputInstructions = $outputRef->invoke($agent);
+
+        self::assertSame(['Custom output'], $outputInstructions);
+    }
+
+    public function testAgentUsesDefaultConfigWhenNoCustomConfigProvided(): void
+    {
+        $agent = new ContentEditorAgent(
+            $this->createMockWorkspaceTooling(),
+            LlmModelName::defaultForContentEditor(),
+            'sk-test-key'
+            // No custom config
+        );
+
+        $ref = new ReflectionMethod(ContentEditorAgent::class, 'getBackgroundInstructions');
+        $ref->setAccessible(true);
+        /** @var list<string> $instructions */
+        $instructions = $ref->invoke($agent);
+
+        // Should contain default instructions
+        self::assertNotEmpty($instructions);
+        $text = implode("\n", $instructions);
+        self::assertStringContainsString('WORKSPACE CONVENTIONS', $text);
     }
 
     private function createMockWorkspaceTooling(): WorkspaceToolingServiceInterface

--- a/tests/Unit/ProjectMgmt/AgentConfigTemplateTest.php
+++ b/tests/Unit/ProjectMgmt/AgentConfigTemplateTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ProjectMgmt;
+
+use App\ProjectMgmt\Domain\ValueObject\AgentConfigTemplate;
+use App\ProjectMgmt\Facade\Enum\ProjectType;
+use PHPUnit\Framework\TestCase;
+
+final class AgentConfigTemplateTest extends TestCase
+{
+    public function testForProjectTypeReturnsTemplateForDefaultType(): void
+    {
+        $template = AgentConfigTemplate::forProjectType(ProjectType::DEFAULT);
+
+        self::assertNotEmpty($template->backgroundInstructions);
+        self::assertNotEmpty($template->stepInstructions);
+        self::assertNotEmpty($template->outputInstructions);
+    }
+
+    public function testDefaultTemplateContainsWorkspaceConventions(): void
+    {
+        $template = AgentConfigTemplate::forProjectType(ProjectType::DEFAULT);
+
+        self::assertStringContainsString('WORKSPACE CONVENTIONS', $template->backgroundInstructions);
+        self::assertStringContainsString('Node.js', $template->backgroundInstructions);
+        self::assertStringContainsString('package.json', $template->backgroundInstructions);
+    }
+
+    public function testDefaultTemplateContainsPathRules(): void
+    {
+        $template = AgentConfigTemplate::forProjectType(ProjectType::DEFAULT);
+
+        self::assertStringContainsString('PATH RULES', $template->backgroundInstructions);
+        self::assertStringContainsString('working folder', $template->backgroundInstructions);
+    }
+
+    public function testDefaultTemplateStepInstructionsContainsWorkflowSteps(): void
+    {
+        $template = AgentConfigTemplate::forProjectType(ProjectType::DEFAULT);
+
+        self::assertStringContainsString('EXPLORE', $template->stepInstructions);
+        self::assertStringContainsString('UNDERSTAND', $template->stepInstructions);
+        self::assertStringContainsString('EDIT', $template->stepInstructions);
+        self::assertStringContainsString('VERIFY', $template->stepInstructions);
+    }
+
+    public function testDefaultTemplateOutputInstructionsContainsSummaryRequirement(): void
+    {
+        $template = AgentConfigTemplate::forProjectType(ProjectType::DEFAULT);
+
+        self::assertStringContainsString('Summarize', $template->outputInstructions);
+    }
+}


### PR DESCRIPTION
Enable customizable AI agent instructions per project, replacing the
previously hardcoded configuration in ContentEditorAgent.

Feature overview:
- Users can customize agent behavior (background, step, output instructions)
  when creating or editing a project
- Default templates are provided per project type via AgentConfigTemplate
- Configuration is stored with the project and used during editor sessions
- A collapsible "Agent Configuration (Advanced)" section in the project form
  keeps the UI clean for non-technical users

Implementation:
- AgentConfigTemplate ValueObject maps ProjectType to default instructions
- Project entity stores 3 TEXT fields (agent_background_instructions,
  agent_step_instructions, agent_output_instructions)
- AgentConfigDto passes configuration through the facade layer
- ContentEditorAgent accepts optional config, falling back to defaults
- RunEditSessionHandler builds AgentConfigDto from project and passes to facade
- API endpoint for fetching templates by project type (for future dynamic UX)

Architecture notes:
- Follows vertical slice boundaries: ProjectMgmt owns templates and storage,
  LlmContentEditor consumes config via facade DTO
- No cross-vertical domain dependencies
- Backward compatible: null config uses existing hardcoded defaults

This implements #33.