### PR TITLE
feat(Remote-Assets): show full URL under filename and search by path/domain

### DIFF
--- a/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
+++ b/src/LlmContentEditor/Domain/Agent/ContentEditorAgent.php
@@ -178,12 +178,12 @@ class ContentEditorAgent extends BaseCodingAgent
 
             Tool::make(
                 'search_remote_content_asset_urls',
-                'Search remote content asset URLs using a regex pattern. Matches against filenames (not full URLs). Returns JSON array of matching URLs. Use for precise filtering when you need specific assets. Examples: "hero" matches files containing hero, "^banner_" matches files starting with banner_, "\\.png$" matches PNG files.'
+                'Search remote content asset URLs using a regex pattern. Matches against the full URL (domain, path, and filename). Returns JSON array of matching URLs. Use for precise filtering when you need specific assets. Examples: "hero" matches URLs containing hero, "uploads" matches URLs with uploads in path or domain, "\\.png$" matches PNG files.'
             )->addProperty(
                 new ToolProperty(
                     'regex_pattern',
                     PropertyType::STRING,
-                    'PCRE regex pattern to match against filenames (without delimiters). Examples: "hero", "^banner_", "\\.jpg$"',
+                    'PCRE regex pattern to match against the full URL (without delimiters). Examples: "hero", "uploads", "\\.jpg$"',
                     true
                 )
             )->setCallable(fn (string $regex_pattern): string => $this->sitebuilderFacade->searchRemoteContentAssetUrls($regex_pattern)),

--- a/src/RemoteContentAssets/Presentation/Resources/assets/controllers/remote_asset_browser_controller.ts
+++ b/src/RemoteContentAssets/Presentation/Resources/assets/controllers/remote_asset_browser_controller.ts
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus";
  * Stimulus controller for browsing remote content assets.
  * Features:
  * - Fetches asset URLs from configured manifest endpoint
- * - Search/filter by filename
+ * - Search/filter by full URL (domain, path, filename)
  * - Scrollable list with configurable visible window size
  * - Image preview for image URLs
  * - Click to open asset in new tab
@@ -64,7 +64,7 @@ export default class extends Controller {
 
     private urls: string[] = [];
     private filteredUrls: string[] = [];
-    private itemHeight: number = 64;
+    private itemHeight: number = 80;
     private isLoading: boolean = false;
     private isUploading: boolean = false;
 
@@ -289,11 +289,7 @@ export default class extends Controller {
         if (query === "") {
             this.filteredUrls = this.urls;
         } else {
-            this.filteredUrls = this.urls.filter((url) => {
-                const filename = this.extractFilename(url).toLowerCase();
-
-                return filename.includes(query);
-            });
+            this.filteredUrls = this.urls.filter((url) => url.toLowerCase().includes(query));
         }
 
         this.updateCount();
@@ -364,9 +360,9 @@ export default class extends Controller {
             previewLink.appendChild(this.createFileIcon());
         }
 
-        // Filename container (flex-1 to take remaining space, but link only wraps text)
+        // Filename container (flex-1 to take remaining space): filename + URL prefix line
         const filenameContainer = document.createElement("div");
-        filenameContainer.className = "flex-1 min-w-0"; // min-w-0 allows truncation to work
+        filenameContainer.className = "flex-1 min-w-0 flex flex-col gap-0.5";
 
         const filenameLink = document.createElement("a");
         filenameLink.href = url;
@@ -380,7 +376,15 @@ export default class extends Controller {
             e.stopPropagation(); // Prevent row click from firing
         });
 
+        const urlPrefix = this.urlWithoutFilename(url);
+        const urlPrefixEl = document.createElement("div");
+        urlPrefixEl.setAttribute("data-remote-asset-url-prefix", "");
+        urlPrefixEl.className = "truncate text-xs text-dark-400 dark:text-dark-500 block max-w-full";
+        urlPrefixEl.textContent = urlPrefix;
+        urlPrefixEl.title = urlPrefix;
+
         filenameContainer.appendChild(filenameLink);
+        filenameContainer.appendChild(urlPrefixEl);
 
         // Add to chat button
         const addButton = document.createElement("button");
@@ -433,6 +437,28 @@ export default class extends Controller {
             const segments = url.split("/").filter(Boolean);
 
             return segments[segments.length - 1] || url;
+        }
+    }
+
+    /**
+     * Base URL (scheme + host + path without filename), with trailing slash.
+     * Used to display the folder/context beneath the filename in the list.
+     */
+    private urlWithoutFilename(url: string): string {
+        try {
+            const urlObj = new URL(url);
+            const pathname = urlObj.pathname;
+            const segments = pathname.split("/").filter(Boolean);
+
+            if (segments.length <= 1) {
+                return urlObj.origin + (pathname.endsWith("/") ? pathname : pathname + "/");
+            }
+
+            const pathWithoutLast = "/" + segments.slice(0, -1).join("/") + "/";
+
+            return urlObj.origin + pathWithoutLast;
+        } catch {
+            return url;
         }
     }
 

--- a/src/WorkspaceTooling/Facade/WorkspaceToolingFacade.php
+++ b/src/WorkspaceTooling/Facade/WorkspaceToolingFacade.php
@@ -145,23 +145,12 @@ final class WorkspaceToolingFacade extends BaseWorkspaceToolingFacade implements
 
         $matchingUrls = [];
         foreach ($urls as $url) {
-            $filename = $this->extractFilenameFromUrl($url);
-            if (preg_match($fullPattern, $filename) === 1) {
+            if (preg_match($fullPattern, $url) === 1) {
                 $matchingUrls[] = $url;
             }
         }
 
         return json_encode($matchingUrls, JSON_THROW_ON_ERROR);
-    }
-
-    private function extractFilenameFromUrl(string $url): string
-    {
-        $path = parse_url($url, PHP_URL_PATH);
-        if ($path === null || $path === false) {
-            return '';
-        }
-
-        return basename($path);
     }
 
     private function isValidRegexPattern(string $pattern): bool

--- a/tests/Unit/WorkspaceTooling/WorkspaceToolingFacadeTest.php
+++ b/tests/Unit/WorkspaceTooling/WorkspaceToolingFacadeTest.php
@@ -376,6 +376,33 @@ final class WorkspaceToolingFacadeTest extends TestCase
         self::assertContains('https://cdn.example.com/images/Hero-Mobile.JPG', $decoded);
     }
 
+    public function testSearchRemoteContentAssetUrlsMatchesFullUrlPathAndDomain(): void
+    {
+        $this->executionContext->setContext(
+            'workspace-id',
+            '/path',
+            null,
+            'project',
+            'image',
+            ['https://example.com/manifest.json']
+        );
+        $remoteContentAssets = $this->createMock(RemoteContentAssetsFacadeInterface::class);
+        $remoteContentAssets->method('fetchAndMergeAssetUrls')->willReturn([
+            'https://foo.com/bar.png',
+            'https://foo.com/uploads/baz.png',
+            'https://uploads.com/bar.png',
+        ]);
+        $facade = $this->createFacadeWithRemoteContentAssets($remoteContentAssets);
+
+        $result = $facade->searchRemoteContentAssetUrls('uploads');
+
+        $decoded = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertCount(2, $decoded);
+        self::assertContains('https://foo.com/uploads/baz.png', $decoded);
+        self::assertContains('https://uploads.com/bar.png', $decoded);
+    }
+
     private function createFacade(): WorkspaceToolingFacade
     {
         $fileOps                   = new FileOperationsService();


### PR DESCRIPTION
## Summary
- **Display**: Show base URL beneath each filename in the Remote-Assets list (small, one line, truncated with ellipsis).
- **Search**: Search field matches the full URL (domain, path, filename), not only the filename (e.g. "uploads" matches path and domain).
- **Agent**: `search_remote_content_asset_urls` tool now matches the full URL; description updated.

## Changes
- **Frontend** (`remote_asset_browser_controller.ts`): `urlWithoutFilename()`, second line with `data-remote-asset-url-prefix`, `filter()` uses full URL, `itemHeight` 80px.
- **Backend** (`WorkspaceToolingFacade`): regex matched against full URL; removed unused `extractFilenameFromUrl`.
- **Agent** (`ContentEditorAgent`): tool description and `regex_pattern` property updated for full-URL matching.
- **Tests**: Frontend tests for path/domain filter and URL prefix in list item; PHP test for full-URL search.

Made with [Cursor](https://cursor.com)