### PR TITLE
feat(prefab): optional PhotoBuilder (e.g. Gemini) provider and API key

### DIFF
--- a/docs/llm-usage-book.md
+++ b/docs/llm-usage-book.md
@@ -79,7 +79,7 @@ These fields are required when creating or editing a project.
 - `photoBuilderLlmModelProvider` -- `openai` or `google`, nullable
 - `photoBuilderLlmModelProviderApiKey` -- the matching API key, nullable
 
-**Fallback rule**: When the PhotoBuilder fields are `null`, the application uses the content editing provider and API key for the PhotoBuilder. This is the default for all projects, including prefab-created projects.
+**Fallback rule**: When the PhotoBuilder fields are `null`, the application uses the content editing provider and API key for the PhotoBuilder. This is the default for all projects, including prefab-created projects. Prefabs can optionally set dedicated PhotoBuilder provider and API key in `prefabs.yaml` (e.g. Google Gemini for image generation) so that the created project uses them instead of the content-editing settings.
 
 The project form offers two options:
 

--- a/prefabs.yaml.example
+++ b/prefabs.yaml.example
@@ -8,10 +8,17 @@
 #   project_link:     Git repository URL (e.g. https://github.com/org/repo.git)
 #   github_access_key: GitHub personal access token
 #   llm_model_provider: One of: openai (see LlmModelProvider enum)
-#   llm_api_key:      API key for the LLM provider
+#   llm_api_key:      API key for the LLM provider (content editing)
 #   keys_visible:     (optional, default true) If false, GitHub and LLM keys are
 #                     set and used by the app but never shown to org users
 #                     (edit form, reuse-existing-key UI).
+#
+# Optional keys for dedicated PhotoBuilder (e.g. Google Gemini image generation):
+#   photo_builder_llm_model_provider: One of: openai, google. If set, photo_builder_llm_api_key is required.
+#   photo_builder_llm_api_key:         API key for the PhotoBuilder provider (image + prompt generation).
+# If both are omitted, PhotoBuilder uses the content-editing LLM settings.
+# When set, the created project will use this provider and key for image generation
+# (e.g. Gemini models). Do not commit real keys; use deployment secrets (CI, gh-secrets, etc.).
 #
 # prefabs:
 #   - name: "My Prefab Project"
@@ -19,4 +26,14 @@
 #     github_access_key: "ghp_xxxxxxxxxxxx"
 #     llm_model_provider: "openai"
 #     llm_api_key: "sk-..."
+#     keys_visible: false
+#
+#   # Example: prefab with dedicated Google Gemini for image generation
+#   - name: "Prefab with Gemini PhotoBuilder"
+#     project_link: "https://github.com/example/other-repo.git"
+#     github_access_key: "ghp_xxxxxxxxxxxx"
+#     llm_model_provider: "openai"
+#     llm_api_key: "sk-..."
+#     photo_builder_llm_model_provider: "google"
+#     photo_builder_llm_api_key: "AIza..."
 #     keys_visible: false

--- a/src/Prefab/Facade/Dto/PrefabDto.php
+++ b/src/Prefab/Facade/Dto/PrefabDto.php
@@ -11,12 +11,14 @@ namespace App\Prefab\Facade\Dto;
 final readonly class PrefabDto
 {
     public function __construct(
-        public string $name,
-        public string $projectLink,
-        public string $githubAccessKey,
-        public string $contentEditingLlmModelProvider,
-        public string $contentEditingLlmApiKey,
-        public bool   $keysVisible = true,
+        public string  $name,
+        public string  $projectLink,
+        public string  $githubAccessKey,
+        public string  $contentEditingLlmModelProvider,
+        public string  $contentEditingLlmApiKey,
+        public bool    $keysVisible = true,
+        public ?string $photoBuilderLlmModelProvider = null,
+        public ?string $photoBuilderLlmApiKey = null,
     ) {
     }
 }

--- a/src/ProjectMgmt/Facade/ProjectMgmtFacade.php
+++ b/src/ProjectMgmt/Facade/ProjectMgmtFacade.php
@@ -40,6 +40,10 @@ final class ProjectMgmtFacade implements ProjectMgmtFacadeInterface
             throw new RuntimeException('Invalid prefab content_editing_llm_model_provider: ' . $prefab->contentEditingLlmModelProvider);
         }
 
+        $photoBuilderProvider = $prefab->photoBuilderLlmModelProvider !== null
+            ? LlmModelProvider::tryFrom($prefab->photoBuilderLlmModelProvider)
+            : null;
+
         $project = $this->projectService->create(
             $organizationId,
             $prefab->name,
@@ -60,8 +64,8 @@ final class ProjectMgmtFacade implements ProjectMgmtFacadeInterface
             null,
             null,
             $prefab->keysVisible,
-            null, // photoBuilderLlmModelProvider: prefabs always use content editing settings
-            null, // photoBuilderLlmModelProviderApiKey
+            $photoBuilderProvider,
+            $prefab->photoBuilderLlmApiKey,
         );
 
         $projectId = $project->getId();

--- a/tests/Unit/Prefab/PrefabLoaderTest.php
+++ b/tests/Unit/Prefab/PrefabLoaderTest.php
@@ -54,6 +54,125 @@ YAML;
             self::assertSame('openai', $result[0]->contentEditingLlmModelProvider);
             self::assertSame('sk-test', $result[0]->contentEditingLlmApiKey);
             self::assertFalse($result[0]->keysVisible);
+            self::assertNull($result[0]->photoBuilderLlmModelProvider);
+            self::assertNull($result[0]->photoBuilderLlmApiKey);
+        } finally {
+            if (is_file($yamlPath)) {
+                unlink($yamlPath);
+            }
+            if (is_dir($tmpDir)) {
+                rmdir($tmpDir);
+            }
+        }
+    }
+
+    public function testLoadPrefabWithDedicatedPhotoBuilderKeys(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/prefab_loader_test_' . uniqid();
+        mkdir($tmpDir, 0755, true);
+        $yamlPath = $tmpDir . '/prefabs.yaml';
+        $yaml     = <<<'YAML'
+prefabs:
+  - name: "Prefab with Gemini"
+    project_link: "https://github.com/example/repo.git"
+    github_access_key: "ghp_xxx"
+    llm_model_provider: "openai"
+    llm_api_key: "sk-xxx"
+    photo_builder_llm_model_provider: "google"
+    photo_builder_llm_api_key: "AIza_xxx"
+    keys_visible: false
+YAML;
+        file_put_contents($yamlPath, $yaml);
+
+        try {
+            $parameterBag = $this->createMock(ParameterBagInterface::class);
+            $parameterBag->method('get')->with('kernel.project_dir')->willReturn($tmpDir);
+            $logger = $this->createMock(LoggerInterface::class);
+
+            $loader = new PrefabLoader($parameterBag, $logger);
+            $result = $loader->load();
+
+            self::assertCount(1, $result);
+            self::assertSame('Prefab with Gemini', $result[0]->name);
+            self::assertSame('google', $result[0]->photoBuilderLlmModelProvider);
+            self::assertSame('AIza_xxx', $result[0]->photoBuilderLlmApiKey);
+        } finally {
+            if (is_file($yamlPath)) {
+                unlink($yamlPath);
+            }
+            if (is_dir($tmpDir)) {
+                rmdir($tmpDir);
+            }
+        }
+    }
+
+    public function testLoadSkipsEntryWhenOnlyPhotoBuilderProviderSet(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/prefab_loader_test_' . uniqid();
+        mkdir($tmpDir, 0755, true);
+        $yamlPath = $tmpDir . '/prefabs.yaml';
+        $yaml     = <<<'YAML'
+prefabs:
+  - name: "Valid One"
+    project_link: "https://github.com/a/repo.git"
+    github_access_key: "ghp_a"
+    llm_model_provider: "openai"
+    llm_api_key: "sk-a"
+  - name: "Invalid photo_builder only provider"
+    project_link: "https://github.com/b/repo.git"
+    github_access_key: "ghp_b"
+    llm_model_provider: "openai"
+    llm_api_key: "sk-b"
+    photo_builder_llm_model_provider: "google"
+YAML;
+        file_put_contents($yamlPath, $yaml);
+
+        try {
+            $parameterBag = $this->createMock(ParameterBagInterface::class);
+            $parameterBag->method('get')->with('kernel.project_dir')->willReturn($tmpDir);
+            $logger = $this->createMock(LoggerInterface::class);
+
+            $loader = new PrefabLoader($parameterBag, $logger);
+            $result = $loader->load();
+
+            self::assertCount(1, $result);
+            self::assertSame('Valid One', $result[0]->name);
+        } finally {
+            if (is_file($yamlPath)) {
+                unlink($yamlPath);
+            }
+            if (is_dir($tmpDir)) {
+                rmdir($tmpDir);
+            }
+        }
+    }
+
+    public function testLoadSkipsEntryWhenInvalidPhotoBuilderProvider(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/prefab_loader_test_' . uniqid();
+        mkdir($tmpDir, 0755, true);
+        $yamlPath = $tmpDir . '/prefabs.yaml';
+        $yaml     = <<<'YAML'
+prefabs:
+  - name: "Bad provider"
+    project_link: "https://github.com/c/repo.git"
+    github_access_key: "ghp_c"
+    llm_model_provider: "openai"
+    llm_api_key: "sk-c"
+    photo_builder_llm_model_provider: "anthropic"
+    photo_builder_llm_api_key: "key"
+YAML;
+        file_put_contents($yamlPath, $yaml);
+
+        try {
+            $parameterBag = $this->createMock(ParameterBagInterface::class);
+            $parameterBag->method('get')->with('kernel.project_dir')->willReturn($tmpDir);
+            $logger = $this->createMock(LoggerInterface::class);
+
+            $loader = new PrefabLoader($parameterBag, $logger);
+            $result = $loader->load();
+
+            self::assertCount(0, $result);
         } finally {
             if (is_file($yamlPath)) {
                 unlink($yamlPath);


### PR DESCRIPTION
## Summary

Allows prefab entries in `prefabs.yaml` to optionally set **dedicated PhotoBuilder** provider and API key (e.g. Google Gemini for image generation), so that projects created from that prefab use them instead of the content-editing LLM settings.

## Changes

- **prefabs.yaml.example**: Document optional `photo_builder_llm_model_provider` and `photo_builder_llm_api_key`; add commented example for Gemini.
- **PrefabDto**: New optional `photoBuilderLlmModelProvider` and `photoBuilderLlmApiKey` (both null when omitted).
- **PrefabLoader**: Parse and validate: both keys must be set or both omitted; provider must be openai/google and support PhotoBuilder; skip invalid entries with warning.
- **ProjectMgmtFacade**: Pass prefab PhotoBuilder provider and key into `ProjectService::create()` when set (no longer always null).
- **Tests**: PrefabLoaderTest — load with dedicated PhotoBuilder keys; skip when only one key set; skip when invalid provider.
- **Docs**: `docs/llm-usage-book.md` — one sentence that prefabs can optionally set dedicated PhotoBuilder in `prefabs.yaml`.

## Behaviour

- When both optional keys are **omitted**: unchanged (PhotoBuilder uses content-editing settings).
- When both are **set** (e.g. `photo_builder_llm_model_provider: "google"`, `photo_builder_llm_api_key: "..."`): the created project gets dedicated PhotoBuilder (Gemini image + prompt models) with that key. Existing `keys_visible` applies to this key as well.

Quality and tests (PHP + frontend) run successfully.