### PR TITLE
Add /hello endpoint returning JSON greeting

### DIFF
--- a/src/StaticPages/Presentation/Controller/ContentController.php
+++ b/src/StaticPages/Presentation/Controller/ContentController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\StaticPages\Presentation\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -43,5 +44,15 @@ class ContentController extends AbstractController
     public function workflowDocsAction(): Response
     {
         return $this->render('@static_pages.presentation/workflow_docs.html.twig');
+    }
+
+    #[Route(
+        path   : '/hello',
+        name   : 'static_pages.presentation.hello',
+        methods: [Request::METHOD_GET]
+    )]
+    public function helloAction(): JsonResponse
+    {
+        return new JsonResponse(['message' => 'Hello, World!']);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a simple `GET /hello` endpoint to the `StaticPages\ContentController` that returns `{"message": "Hello, World!"}` as a `JsonResponse`
- No new files created — single method addition to the existing controller
- Endpoint is available at `/{_locale}/hello` (e.g., `/en/hello`) consistent with all other routes

## Test plan

- [ ] Verify `GET /{_locale}/hello` returns HTTP 200 with `{"message": "Hello, World!"}`
- [ ] Run `mise run quality` to confirm code standards pass
- [ ] Run `mise run tests` to confirm no regressions


Made with [Cursor](https://cursor.com)