### PR TITLE
Add auth-free API endpoint that lists all project names

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/api, roles: PUBLIC_ACCESS }
         - { path: ^/sign-in, roles: PUBLIC_ACCESS }
         - { path: ^/sign-up, roles: PUBLIC_ACCESS }
         - { path: "^/organization/invitation/[^/]+$", roles: PUBLIC_ACCESS }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -7,13 +7,18 @@ root_redirect:
         permanent: false
 
 controller:
-    resource: "../src/**/*Controller.php"
+    resource: "../src/**/Presentation/Controller/*Controller.php"
     type: attribute
     prefix: /{_locale}
     requirements:
         _locale: en|de
     defaults:
         _locale: en
+
+api_controllers:
+    resource: "../src/**/Api/Controller/*Controller.php"
+    type: attribute
+    prefix: /api
 
 shared:
     resource: "@SharedBundle/config/routes.yaml"

--- a/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
+++ b/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Api\Controller;
+
+use App\ProjectMgmt\Domain\Service\ProjectService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProjectNamesApiController
+{
+    public function __construct(
+        private readonly ProjectService $projectService,
+    ) {
+    }
+
+    #[Route(path: '/project-names', name: 'project_mgmt.api.project_names', methods: ['GET'])]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse(['projects' => $this->projectService->findAllProjectNames()]);
+    }
+}

--- a/src/ProjectMgmt/Domain/Service/ProjectService.php
+++ b/src/ProjectMgmt/Domain/Service/ProjectService.php
@@ -173,6 +173,23 @@ final class ProjectService
     }
 
     /**
+     * @return list<string>
+     */
+    public function findAllProjectNames(): array
+    {
+        /** @var list<array{name: string}> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('p.name')
+            ->from(Project::class, 'p')
+            ->where('p.deletedAt IS NULL')
+            ->orderBy('p.name', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_column($rows, 'name');
+    }
+
+    /**
      * Find all non-deleted projects for an organization.
      *
      * @return list<Project>

--- a/tests/Integration/ProjectMgmt/ProjectNamesApiTest.php
+++ b/tests/Integration/ProjectMgmt/ProjectNamesApiTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\ProjectMgmt;
+
+use App\Account\Domain\Service\AccountDomainService;
+use App\Account\Facade\AccountFacadeInterface;
+use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Domain\Entity\Project;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ProjectNamesApiTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+    private ?string $testOrganizationId = null;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $container    = static::getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager       = $container->get(EntityManagerInterface::class);
+        $this->entityManager = $entityManager;
+    }
+
+    public function testReturnsEmptyListWhenNoProjectsExist(): void
+    {
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame(['projects' => []], $data);
+    }
+
+    public function testReturnsProjectNames(): void
+    {
+        $this->createOrganization();
+        $this->createProject('Alpha Project');
+        $this->createProject('Beta Project');
+
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame(['projects' => ['Alpha Project', 'Beta Project']], $data);
+    }
+
+    public function testExcludesDeletedProjects(): void
+    {
+        $this->createOrganization();
+        $this->createProject('Active Project');
+        $deleted = $this->createProject('Deleted Project');
+        $deleted->markAsDeleted();
+        $this->entityManager->flush();
+
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame(['projects' => ['Active Project']], $data);
+    }
+
+    public function testEndpointIsAccessibleWithoutAuthentication(): void
+    {
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    private function createOrganization(): void
+    {
+        $container = static::getContainer();
+
+        /** @var AccountDomainService $accountDomainService */
+        $accountDomainService = $container->get(AccountDomainService::class);
+
+        /** @var AccountFacadeInterface $accountFacade */
+        $accountFacade = $container->get(AccountFacadeInterface::class);
+
+        $user   = $accountDomainService->register('api-test-' . uniqid() . '@example.com', 'password123');
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $this->testOrganizationId = $accountFacade->getCurrentlyActiveOrganizationIdForAccountCore($userId);
+        self::assertNotNull($this->testOrganizationId);
+    }
+
+    private function createProject(string $name): Project
+    {
+        self::assertNotNull($this->testOrganizationId, 'Must create organization before creating project');
+
+        $project = new Project(
+            $this->testOrganizationId,
+            $name,
+            'https://github.com/test/repo.git',
+            'ghp_testtoken123',
+            LlmModelProvider::OpenAI,
+            'sk-test-key-123'
+        );
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `/api/project-names` GET endpoint that returns a JSON list of all non-deleted content project names, accessible without authentication
- Splits route configuration to support both locale-prefixed Presentation controllers and prefix-free API controllers under `/api`
- Adds `PUBLIC_ACCESS` security rule for `/api` paths so the endpoint requires no login

## Changes

| File | Change |
|------|--------|
| `config/routes.yaml` | Split route imports — Presentation controllers keep `/{_locale}` prefix, new Api controllers use `/api` prefix |
| `config/packages/security.yaml` | Add `PUBLIC_ACCESS` rule for `^/api` paths (first in access_control list) |
| `src/ProjectMgmt/Domain/Service/ProjectService.php` | Add `findAllProjectNames()` method — efficient scalar DQL query returning `list<string>` |
| `src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php` | **New** — API controller returning `{"projects": ["Name1", "Name2", ...]}` |
| `tests/Integration/ProjectMgmt/ProjectNamesApiTest.php` | **New** — Integration tests for empty list, populated list, soft-delete exclusion, and unauthenticated access |

## Test plan

- [ ] `GET /api/project-names` returns `200` with `{"projects": []}` when no projects exist
- [ ] `GET /api/project-names` returns project names sorted alphabetically
- [ ] Soft-deleted projects are excluded from the response
- [ ] Endpoint is accessible without authentication (no login required)
- [ ] Existing locale-prefixed routes still work correctly after route import change

Closes #117


Made with [Cursor](https://cursor.com)