### PR TITLE
Add public API endpoint to list all project names

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/api/, roles: PUBLIC_ACCESS }
         - { path: ^/sign-in, roles: PUBLIC_ACCESS }
         - { path: ^/sign-up, roles: PUBLIC_ACCESS }
         - { path: "^/organization/invitation/[^/]+$", roles: PUBLIC_ACCESS }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -6,8 +6,12 @@ root_redirect:
         path: /en/
         permanent: false
 
-controller:
-    resource: "../src/**/*Controller.php"
+api_controllers:
+    resource: "../src/**/Api/**/*Controller.php"
+    type: attribute
+
+presentation_controllers:
+    resource: "../src/**/Presentation/**/*Controller.php"
     type: attribute
     prefix: /{_locale}
     requirements:

--- a/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
+++ b/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Api\Controller;
+
+use App\ProjectMgmt\Domain\Service\ProjectService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProjectNamesApiController extends AbstractController
+{
+    public function __construct(
+        private readonly ProjectService $projectService,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/project-names',
+        name: 'project_mgmt.api.project_names',
+        methods: [Request::METHOD_GET]
+    )]
+    public function list(): JsonResponse
+    {
+        return new JsonResponse([
+            'projectNames' => $this->projectService->getAllProjectNames(),
+        ]);
+    }
+}

--- a/src/ProjectMgmt/Domain/Service/ProjectService.php
+++ b/src/ProjectMgmt/Domain/Service/ProjectService.php
@@ -173,6 +173,23 @@ final class ProjectService
     }
 
     /**
+     * @return list<string>
+     */
+    public function getAllProjectNames(): array
+    {
+        /** @var list<array{name: string}> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('p.name')
+            ->from(Project::class, 'p')
+            ->where('p.deletedAt IS NULL')
+            ->orderBy('p.name', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(static fn (array $row): string => $row['name'], $rows);
+    }
+
+    /**
      * Find all non-deleted projects for an organization.
      *
      * @return list<Project>

--- a/tests/Integration/ProjectMgmt/ProjectNamesApiTest.php
+++ b/tests/Integration/ProjectMgmt/ProjectNamesApiTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\ProjectMgmt;
+
+use App\Account\Domain\Service\AccountDomainService;
+use App\Account\Facade\AccountFacadeInterface;
+use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Domain\Entity\Project;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ProjectNamesApiTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+    private ?string $testOrganizationId = null;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $container    = static::getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager       = $container->get(EntityManagerInterface::class);
+        $this->entityManager = $entityManager;
+    }
+
+    public function testReturnsEmptyListWhenNoProjectsExist(): void
+    {
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('projectNames', $data);
+        self::assertSame([], $data['projectNames']);
+    }
+
+    public function testReturnsOnlyNonDeletedProjectNames(): void
+    {
+        $this->createTestOrganization();
+
+        $this->createProject('Active Alpha');
+        $this->createProject('Active Beta');
+        $deletedProject = $this->createProject('Deleted Gamma');
+
+        $deletedProject->markAsDeleted();
+        $this->entityManager->flush();
+
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+
+        $data = $this->decodeResponse();
+        self::assertSame(['Active Alpha', 'Active Beta'], $data['projectNames']);
+    }
+
+    public function testReturnsNamesInAlphabeticalOrder(): void
+    {
+        $this->createTestOrganization();
+
+        $this->createProject('Zulu');
+        $this->createProject('Alpha');
+        $this->createProject('Mike');
+
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+
+        $data = $this->decodeResponse();
+        self::assertSame(['Alpha', 'Mike', 'Zulu'], $data['projectNames']);
+    }
+
+    public function testAccessibleWithoutAuthentication(): void
+    {
+        $this->client->request('GET', '/api/project-names');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    private function createTestOrganization(): void
+    {
+        $container = static::getContainer();
+
+        /** @var AccountDomainService $accountDomainService */
+        $accountDomainService = $container->get(AccountDomainService::class);
+
+        /** @var AccountFacadeInterface $accountFacade */
+        $accountFacade = $container->get(AccountFacadeInterface::class);
+
+        $user   = $accountDomainService->register('api-test-' . uniqid() . '@example.com', 'password123');
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $this->testOrganizationId = $accountFacade->getCurrentlyActiveOrganizationIdForAccountCore($userId);
+        self::assertNotNull($this->testOrganizationId);
+    }
+
+    /**
+     * @return array{projectNames: list<string>}
+     */
+    private function decodeResponse(): array
+    {
+        $content = (string) $this->client->getResponse()->getContent();
+        $decoded = json_decode($content, true);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('projectNames', $decoded);
+
+        /** @var array{projectNames: list<string>} $decoded */
+        return $decoded;
+    }
+
+    private function createProject(string $name): Project
+    {
+        self::assertNotNull($this->testOrganizationId, 'Must create organization before creating project');
+
+        $project = new Project(
+            $this->testOrganizationId,
+            $name,
+            'https://github.com/test/repo.git',
+            'ghp_testtoken123',
+            LlmModelProvider::OpenAI,
+            'sk-test-key-123'
+        );
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/project-names` endpoint that returns a JSON list of all non-deleted content project names, sorted alphabetically
- Split route configuration into API controllers (no locale prefix) and Presentation controllers (with `/{_locale}` prefix) for clean separation
- Add `PUBLIC_ACCESS` security rule for `/api/` paths so the endpoint requires no authentication

## Changes

| File | Change |
|------|--------|
| `config/routes.yaml` | Split single controller import into `api_controllers` and `presentation_controllers` groups |
| `config/packages/security.yaml` | Add `PUBLIC_ACCESS` rule for `^/api/` paths |
| `src/ProjectMgmt/Domain/Service/ProjectService.php` | Add `getAllProjectNames()` method using DQL to select only names |
| `src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php` | New API controller with single GET endpoint |
| `tests/Integration/ProjectMgmt/ProjectNamesApiTest.php` | Integration tests: empty list, non-deleted filtering, alphabetical order, no-auth access |

## Test plan

- [x] PHPStan passes with no errors
- [x] PHP CS Fixer passes with no issues
- [x] Architecture tests pass (144 tests, boundary checks)
- [x] Unit tests pass (356 tests)
- [ ] Integration tests (require database — run in CI)
- [ ] Frontend tests (no frontend changes)

Closes #117

Made with [Cursor](https://cursor.com)