### PR TITLE
feat: add auth-free API endpoint for content project names

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -37,6 +37,7 @@ security:
         - { path: ^/sign-in, roles: PUBLIC_ACCESS }
         - { path: ^/sign-up, roles: PUBLIC_ACCESS }
         - { path: "^/organization/invitation/[^/]+$", roles: PUBLIC_ACCESS }
+        - { path: ^/api/, roles: PUBLIC_ACCESS }
         - { path: ^/review, roles: ROLE_USER }
         - { path: ^/projects, roles: ROLE_USER }
         - { path: ^/conversation, roles: ROLE_USER }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -6,8 +6,12 @@ root_redirect:
         path: /en/
         permanent: false
 
+api:
+    resource: "../src/**/Api/Controller/*Controller.php"
+    type: attribute
+
 controller:
-    resource: "../src/**/*Controller.php"
+    resource: "../src/**/Presentation/Controller/*Controller.php"
     type: attribute
     prefix: /{_locale}
     requirements:

--- a/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
+++ b/src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Api\Controller;
+
+use App\ProjectMgmt\Domain\Service\ProjectService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProjectNamesApiController extends AbstractController
+{
+    public function __construct(
+        private readonly ProjectService $projectService,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/content-projects',
+        name: 'project_mgmt.api.content_project_names',
+        methods: [Request::METHOD_GET],
+    )]
+    public function list(): JsonResponse
+    {
+        return new JsonResponse($this->projectService->getAllNonDeletedProjectNames());
+    }
+}

--- a/src/ProjectMgmt/Domain/Service/ProjectService.php
+++ b/src/ProjectMgmt/Domain/Service/ProjectService.php
@@ -194,6 +194,23 @@ final class ProjectService
     }
 
     /**
+     * @return list<string>
+     */
+    public function getAllNonDeletedProjectNames(): array
+    {
+        /** @var list<string> $names */
+        $names = $this->entityManager->createQueryBuilder()
+            ->select('p.name')
+            ->from(Project::class, 'p')
+            ->where('p.deletedAt IS NULL')
+            ->orderBy('p.name', 'ASC')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return $names;
+    }
+
+    /**
      * Find all soft-deleted projects for an organization.
      *
      * @return list<Project>

--- a/tests/Application/ProjectMgmt/ContentProjectNamesApiTest.php
+++ b/tests/Application/ProjectMgmt/ContentProjectNamesApiTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\ProjectMgmt;
+
+use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Domain\Service\ProjectService;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ContentProjectNamesApiTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private ProjectService $projectService;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $container    = static::getContainer();
+
+        /** @var ProjectService $projectService */
+        $projectService       = $container->get(ProjectService::class);
+        $this->projectService = $projectService;
+    }
+
+    public function testEndpointReturnsJsonArrayWithoutAuthentication(): void
+    {
+        $this->client->request('GET', '/api/content-projects');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        $decoded = json_decode($content, true);
+        self::assertIsArray($decoded);
+    }
+
+    public function testEndpointReturnsCreatedProjectName(): void
+    {
+        $projectName = 'API Test Project ' . uniqid();
+
+        $this->projectService->create(
+            '00000000-0000-0000-0000-000000000000',
+            $projectName,
+            'https://github.com/test/repo.git',
+            'fake-token',
+            LlmModelProvider::OpenAI,
+            'fake-api-key',
+        );
+
+        $this->client->request('GET', '/api/content-projects');
+
+        self::assertResponseIsSuccessful();
+
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        $decoded = json_decode($content, true);
+        self::assertIsArray($decoded);
+        self::assertContains($projectName, $decoded);
+    }
+
+    public function testEndpointExcludesDeletedProjects(): void
+    {
+        $projectName = 'Deleted API Test Project ' . uniqid();
+
+        $project = $this->projectService->create(
+            '00000000-0000-0000-0000-000000000000',
+            $projectName,
+            'https://github.com/test/repo.git',
+            'fake-token',
+            LlmModelProvider::OpenAI,
+            'fake-api-key',
+        );
+
+        $this->projectService->delete($project);
+
+        $this->client->request('GET', '/api/content-projects');
+
+        self::assertResponseIsSuccessful();
+
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        $decoded = json_decode($content, true);
+        self::assertIsArray($decoded);
+        self::assertNotContains($projectName, $decoded);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a public `GET /api/content-projects` endpoint that returns a JSON array of all non-deleted content project names, ordered alphabetically
- Create `ProjectNamesApiController` in the `ProjectMgmt/Api` layer with a dedicated `getAllNonDeletedProjectNames()` query on `ProjectService`
- Configure locale-free routing for `Api/Controller` classes and `PUBLIC_ACCESS` security for `/api/` paths

## Changes

| File | Change |
|------|--------|
| `src/ProjectMgmt/Domain/Service/ProjectService.php` | Add `getAllNonDeletedProjectNames()` method with efficient single-column DQL query |
| `src/ProjectMgmt/Api/Controller/ProjectNamesApiController.php` | **New** — API controller returning JSON list |
| `config/routes.yaml` | Add locale-free route import for Api controllers; narrow existing import to Presentation controllers |
| `config/packages/security.yaml` | Add `PUBLIC_ACCESS` rule for `/api/` paths |
| `tests/Application/ProjectMgmt/ContentProjectNamesApiTest.php` | **New** — 3 application tests (auth-free access, project inclusion, soft-delete exclusion) |

## Test plan

- [x] Architecture tests pass (144 assertions) — Api layer properly isolated
- [x] Unit/integration tests pass (108 tests, 653 assertions)
- [x] Application tests pass (9 tests, 52 assertions) including 3 new tests
- [ ] Manual verification: `curl /api/content-projects` returns a JSON array of project name strings

Closes #131

Made with [Cursor](https://cursor.com)