### PR TITLE
Add public API endpoint for project names

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/api/, roles: PUBLIC_ACCESS }
         - { path: ^/sign-in, roles: PUBLIC_ACCESS }
         - { path: ^/sign-up, roles: PUBLIC_ACCESS }
         - { path: "^/organization/invitation/[^/]+$", roles: PUBLIC_ACCESS }

--- a/src/ProjectMgmt/Api/Controller/ProjectNameApiController.php
+++ b/src/ProjectMgmt/Api/Controller/ProjectNameApiController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Api\Controller;
+
+use App\ProjectMgmt\Api\Dto\ProjectNameDto;
+use App\ProjectMgmt\Facade\Dto\ProjectInfoDto;
+use App\ProjectMgmt\Facade\ProjectMgmtFacadeInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(
+    path: '/api/project-names',
+    name: 'project_mgmt.api.project_names',
+    methods: [Request::METHOD_GET]
+)]
+final class ProjectNameApiController extends AbstractController
+{
+    public function __construct(
+        private readonly ProjectMgmtFacadeInterface $projectMgmtFacade,
+    ) {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        $projects = $this->projectMgmtFacade->getProjectInfos();
+        $names    = array_map(
+            static fn (ProjectInfoDto $p) => new ProjectNameDto($p->id, $p->name),
+            $projects
+        );
+
+        return $this->json($names);
+    }
+}

--- a/src/ProjectMgmt/Api/Dto/ProjectNameDto.php
+++ b/src/ProjectMgmt/Api/Dto/ProjectNameDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProjectMgmt\Api\Dto;
+
+final readonly class ProjectNameDto
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Unit/ProjectMgmt/ProjectNameApiControllerTest.php
+++ b/tests/Unit/ProjectMgmt/ProjectNameApiControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ProjectMgmt;
+
+use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Api\Controller\ProjectNameApiController;
+use App\ProjectMgmt\Facade\Dto\ProjectInfoDto;
+use App\ProjectMgmt\Facade\Enum\ProjectType;
+use App\ProjectMgmt\Facade\ProjectMgmtFacadeInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+final class ProjectNameApiControllerTest extends TestCase
+{
+    public function testReturnsProjectNamesAsJson(): void
+    {
+        $facade = $this->createMock(ProjectMgmtFacadeInterface::class);
+        $facade->method('getProjectInfos')->willReturn([
+            $this->createProjectInfoDto('id-1', 'Project Alpha'),
+            $this->createProjectInfoDto('id-2', 'Project Beta'),
+        ]);
+
+        $controller = new ProjectNameApiController($facade);
+        $controller->setContainer(new Container());
+
+        $response = $controller->__invoke();
+
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var list<array{id: string, name: string}> $data */
+        $data = json_decode((string) $response->getContent(), true);
+        self::assertCount(2, $data);
+        self::assertSame(['id' => 'id-1', 'name' => 'Project Alpha'], $data[0]);
+        self::assertSame(['id' => 'id-2', 'name' => 'Project Beta'], $data[1]);
+    }
+
+    public function testReturnsEmptyArrayWhenNoProjects(): void
+    {
+        $facade = $this->createMock(ProjectMgmtFacadeInterface::class);
+        $facade->method('getProjectInfos')->willReturn([]);
+
+        $controller = new ProjectNameApiController($facade);
+        $controller->setContainer(new Container());
+
+        $response = $controller->__invoke();
+
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var list<mixed> $data */
+        $data = json_decode((string) $response->getContent(), true);
+        self::assertSame([], $data);
+    }
+
+    public function testResponseContainsOnlyIdAndNameFields(): void
+    {
+        $facade = $this->createMock(ProjectMgmtFacadeInterface::class);
+        $facade->method('getProjectInfos')->willReturn([
+            new ProjectInfoDto(
+                'id-secret',
+                'Sensitive Project',
+                'https://github.com/org/secret.git',
+                'ghp_supersecret',
+                ProjectType::DEFAULT,
+                'https://github.com/org/secret',
+                'agent:latest',
+                LlmModelProvider::OpenAI,
+                'sk-supersecretkey',
+                'background',
+                'step',
+                'output',
+                [],
+                'my-bucket',
+                'us-east-1',
+                'AKIAIOSFODNN7',
+                's3-secret-key',
+            ),
+        ]);
+
+        $controller = new ProjectNameApiController($facade);
+        $controller->setContainer(new Container());
+
+        $response = $controller->__invoke();
+
+        /** @var list<array<string, string>> $data */
+        $data = json_decode((string) $response->getContent(), true);
+        self::assertCount(1, $data);
+        self::assertSame(['id', 'name'], array_keys($data[0]));
+        self::assertSame('id-secret', $data[0]['id']);
+        self::assertSame('Sensitive Project', $data[0]['name']);
+    }
+
+    private function createProjectInfoDto(string $id, string $name): ProjectInfoDto
+    {
+        return new ProjectInfoDto(
+            $id,
+            $name,
+            'https://github.com/org/repo.git',
+            'ghp_token',
+            ProjectType::DEFAULT,
+            'https://github.com/org/repo',
+            'agent:latest',
+            LlmModelProvider::OpenAI,
+            'sk-key',
+            'background',
+            'step',
+            'output',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new public `GET /api/project-names` endpoint that returns a JSON list of `{id, name}` objects for all non-deleted projects
- Creates `ProjectNameDto` (in `Api/Dto/`) to ensure only safe fields (id and name) are exposed — no API keys, tokens, or S3 credentials leak
- Configures `PUBLIC_ACCESS` for the `/api/` URL prefix in `security.yaml`, establishing a clean pattern for future public API routes

Closes #135

## Test plan

- [x] PHPStan passes with no errors
- [x] PHP CS Fixer passes with no issues
- [x] Architecture tests pass (Api layer correctly isolated)
- [x] Unit tests verify:
  - Correct JSON response with multiple projects
  - Empty array when no projects exist
  - Response contains **only** `id` and `name` fields (no sensitive data)
- [ ] Manual: `curl /api/project-names` returns expected JSON without authentication

Made with [Cursor](https://cursor.com)