### PR TITLE
Project cloning feature

### DIFF
--- a/src/ProjectMgmt/Domain/Service/ProjectService.php
+++ b/src/ProjectMgmt/Domain/Service/ProjectService.php
@@ -79,6 +79,33 @@ final class ProjectService
         return $project;
     }
 
+    public function cloneProject(Project $sourceProject, string $name): Project
+    {
+        return $this->create(
+            $sourceProject->getOrganizationId(),
+            $name,
+            $sourceProject->getGitUrl(),
+            $sourceProject->getGithubToken(),
+            $sourceProject->getContentEditingLlmModelProvider(),
+            $sourceProject->getContentEditingLlmModelProviderApiKey(),
+            $sourceProject->getProjectType(),
+            $sourceProject->getAgentImage(),
+            $sourceProject->getAgentBackgroundInstructions(),
+            $sourceProject->getAgentStepInstructions(),
+            $sourceProject->getAgentOutputInstructions(),
+            $sourceProject->getRemoteContentAssetsManifestUrls(),
+            $sourceProject->getS3BucketName(),
+            $sourceProject->getS3Region(),
+            $sourceProject->getS3AccessKeyId(),
+            $sourceProject->getS3SecretAccessKey(),
+            $sourceProject->getS3IamRoleArn(),
+            $sourceProject->getS3KeyPrefix(),
+            $sourceProject->isKeysVisible(),
+            $sourceProject->getPhotoBuilderLlmModelProvider(),
+            $sourceProject->getPhotoBuilderLlmModelProviderApiKey(),
+        );
+    }
+
     /**
      * @param list<string>|null $remoteContentAssetsManifestUrls
      */

--- a/src/ProjectMgmt/Presentation/Controller/ProjectController.php
+++ b/src/ProjectMgmt/Presentation/Controller/ProjectController.php
@@ -8,6 +8,7 @@ use App\Account\Facade\AccountFacadeInterface;
 use App\ChatBasedContentEditor\Facade\ChatBasedContentEditorFacadeInterface;
 use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
 use App\LlmContentEditor\Facade\LlmContentEditorFacadeInterface;
+use App\ProjectMgmt\Domain\Entity\Project;
 use App\ProjectMgmt\Domain\Service\ProjectService;
 use App\ProjectMgmt\Facade\Dto\ExistingLlmApiKeyDto;
 use App\ProjectMgmt\Facade\Enum\ProjectType;
@@ -229,6 +230,65 @@ final class ProjectController extends AbstractController
             $photoBuilderApiKey,
         );
         $this->addFlash('success', $this->translator->trans('flash.success.project_created'));
+
+        return $this->redirectToRoute('project_mgmt.presentation.list');
+    }
+
+    #[Route(
+        path: '/projects/{id}/clone',
+        name: 'project_mgmt.presentation.clone',
+        methods: [Request::METHOD_GET],
+        requirements: ['id' => '[a-f0-9-]{36}']
+    )]
+    public function showCloneForm(string $id): Response
+    {
+        $organizationId = $this->getActiveOrganizationId();
+        if ($organizationId === null) {
+            $this->addFlash('error', $this->translator->trans('flash.error.no_organization'));
+
+            return $this->redirectToRoute('account.presentation.dashboard');
+        }
+
+        $sourceProject = $this->getAccessibleProjectOrThrowNotFound($id, $organizationId);
+
+        return $this->render('@project_mgmt.presentation/project_clone_form.twig', [
+            'sourceProject'        => $sourceProject,
+            'suggestedProjectName' => $this->buildCloneProjectName($sourceProject->getName()),
+        ]);
+    }
+
+    #[Route(
+        path: '/projects/{id}/clone',
+        name: 'project_mgmt.presentation.clone_submit',
+        methods: [Request::METHOD_POST],
+        requirements: ['id' => '[a-f0-9-]{36}']
+    )]
+    public function cloneSubmit(string $id, Request $request): Response
+    {
+        $organizationId = $this->getActiveOrganizationId();
+        if ($organizationId === null) {
+            $this->addFlash('error', $this->translator->trans('flash.error.no_organization'));
+
+            return $this->redirectToRoute('account.presentation.dashboard');
+        }
+
+        $sourceProject = $this->getAccessibleProjectOrThrowNotFound($id, $organizationId);
+
+        if (!$this->isCsrfTokenValid('project_clone_' . $id, $request->request->getString('_csrf_token'))) {
+            $this->addFlash('error', $this->translator->trans('flash.error.invalid_csrf'));
+
+            return $this->redirectToRoute('project_mgmt.presentation.clone', ['id' => $id]);
+        }
+
+        $name = trim($request->request->getString('name'));
+        if ($name === '') {
+            $this->addFlash('error', $this->translator->trans('flash.error.project_clone_name_required'));
+
+            return $this->redirectToRoute('project_mgmt.presentation.clone', ['id' => $id]);
+        }
+
+        $clonedProject = $this->projectService->cloneProject($sourceProject, $name);
+        $this->addFlash('success', $this->translator->trans('flash.success.project_cloned', ['%name%' => $clonedProject->getName()]));
 
         return $this->redirectToRoute('project_mgmt.presentation.list');
     }
@@ -685,6 +745,22 @@ final class ProjectController extends AbstractController
     private function nullIfEmpty(string $value): ?string
     {
         return $value === '' ? null : $value;
+    }
+
+    private function buildCloneProjectName(string $sourceProjectName): string
+    {
+        return $this->translator->trans('project.clone.default_name', ['%name%' => $sourceProjectName]);
+    }
+
+    private function getAccessibleProjectOrThrowNotFound(string $projectId, string $organizationId): Project
+    {
+        $project = $this->projectService->findById($projectId);
+
+        if ($project === null || $project->isDeleted() || $project->getOrganizationId() !== $organizationId) {
+            throw $this->createNotFoundException('Project not found.');
+        }
+
+        return $project;
     }
 
     /**

--- a/src/ProjectMgmt/Presentation/Resources/templates/project_clone_form.twig
+++ b/src/ProjectMgmt/Presentation/Resources/templates/project_clone_form.twig
@@ -1,0 +1,63 @@
+{% extends '@common.presentation/base_appshell.html.twig' %}
+
+{% block title %}{{ 'project.clone.title'|trans }}{% endblock %}
+
+{% block content %}
+    <div class="max-w-2xl mx-auto space-y-6" data-test-id="project-clone-page">
+        <div>
+            <h1 class="text-2xl font-semibold text-dark-900 dark:text-dark-100">{{ 'project.clone.heading'|trans }}</h1>
+            <p class="text-dark-600 dark:text-dark-400 mt-1">
+                {{ 'project.clone.description'|trans({'%name%': sourceProject.name}) }}
+            </p>
+        </div>
+
+        {% for message in app.flashes('error') %}
+            <div class="rounded-md bg-red-50 dark:bg-red-900/20 p-4">
+                <p class="text-sm text-red-700 dark:text-red-400">{{ message }}</p>
+            </div>
+        {% endfor %}
+
+        <form method="post"
+              action="{{ path('project_mgmt.presentation.clone_submit', { id: sourceProject.id }) }}"
+              data-test-id="project-clone-form"
+              class="space-y-6 bg-white dark:bg-dark-800 rounded-lg border border-dark-200 dark:border-dark-700 p-6">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('project_clone_' ~ sourceProject.id) }}">
+
+            <div>
+                <label for="name" class="block text-sm font-medium text-dark-700 dark:text-dark-300 mb-1">
+                    {{ 'project.clone.project_name'|trans }}
+                </label>
+                <input type="text"
+                       name="name"
+                       id="name"
+                       data-test-id="project-clone-name"
+                       value="{{ suggestedProjectName }}"
+                       required
+                       placeholder="{{ 'project.clone.project_name_placeholder'|trans }}"
+                       class="w-full px-3 py-2 border border-dark-300 dark:border-dark-600 rounded-md bg-white dark:bg-dark-800 text-dark-900 dark:text-dark-100 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500">
+            </div>
+
+            <div class="rounded-lg border border-dark-200 dark:border-dark-700 bg-dark-50 dark:bg-dark-900 p-4">
+                <p class="text-sm text-dark-700 dark:text-dark-300">
+                    <span class="font-medium">{{ 'project.clone.source_project'|trans }}</span>
+                    {{ sourceProject.name }}
+                </p>
+                <p class="mt-1 text-xs text-dark-500 dark:text-dark-400 font-mono break-all">
+                    {{ sourceProject.gitUrl }}
+                </p>
+            </div>
+
+            <div class="flex items-center justify-end gap-3 pt-4 border-t border-dark-200 dark:border-dark-700">
+                <a href="{{ path('project_mgmt.presentation.list') }}"
+                   class="px-4 py-2 rounded-md border border-dark-300 dark:border-dark-600 text-dark-700 dark:text-dark-300 text-sm font-medium hover:bg-dark-100 dark:hover:bg-dark-700 focus:outline-none focus:ring-2 focus:ring-primary-500">
+                    {{ 'common.cancel'|trans }}
+                </a>
+                <button type="submit"
+                        data-test-id="project-clone-submit"
+                        class="px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-dark-900">
+                    {{ 'project.clone.submit'|trans }}
+                </button>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/src/ProjectMgmt/Presentation/Resources/templates/project_list.twig
+++ b/src/ProjectMgmt/Presentation/Resources/templates/project_list.twig
@@ -114,6 +114,11 @@
                                    class="inline-flex items-center px-3 py-1.5 rounded-md border border-dark-300 dark:border-dark-600 text-dark-700 dark:text-dark-300 text-sm font-medium hover:bg-dark-100 dark:hover:bg-dark-700">
                                     {{ 'project.list.edit_details'|trans }}
                                 </a>
+                                <a href="{{ path('project_mgmt.presentation.clone', { id: item.project.id }) }}"
+                                   data-test-class="project-list-clone-link"
+                                   class="inline-flex items-center px-3 py-1.5 rounded-md border border-dark-300 dark:border-dark-600 text-dark-700 dark:text-dark-300 text-sm font-medium hover:bg-dark-100 dark:hover:bg-dark-700">
+                                    {{ 'project.list.clone_project'|trans }}
+                                </a>
                                 {% if item.workspace %}
                                     <form action="{{ path('project_mgmt.presentation.reset_workspace', { id: item.project.id }) }}"
                                           method="post"

--- a/src/RemoteContentAssets/Presentation/Resources/assets/controllers/remote_asset_browser_controller.ts
+++ b/src/RemoteContentAssets/Presentation/Resources/assets/controllers/remote_asset_browser_controller.ts
@@ -567,8 +567,8 @@ export default class extends Controller {
 
     private formatUploadPartialFailureLabel(errorCount: number, total: number): string {
         return this.uploadPartialFailureLabelValue
-            .replaceAll("%errorCount%", String(errorCount))
-            .replaceAll("%total%", String(total));
+            .replace(/%errorCount%/g, String(errorCount))
+            .replace(/%total%/g, String(total));
     }
 
     private getUploadErrorFallbackLabel(): string {

--- a/tests/Integration/ProjectMgmt/ProjectCloneTest.php
+++ b/tests/Integration/ProjectMgmt/ProjectCloneTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\ProjectMgmt;
+
+use App\Account\Domain\Entity\AccountCore;
+use App\Account\Domain\Service\AccountDomainService;
+use App\Account\Facade\AccountFacadeInterface;
+use App\LlmContentEditor\Facade\Enum\LlmModelProvider;
+use App\ProjectMgmt\Domain\Entity\Project;
+use App\ProjectMgmt\Facade\Enum\ProjectType;
+use App\Tests\Support\SecurityUserLoginTrait;
+use App\WorkspaceMgmt\Domain\Entity\Workspace;
+use App\WorkspaceMgmt\Facade\Enum\WorkspaceStatus;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Integration tests for cloning projects.
+ */
+final class ProjectCloneTest extends WebTestCase
+{
+    use SecurityUserLoginTrait;
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+    private AccountDomainService $accountDomainService;
+    private AccountFacadeInterface $accountFacade;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $container    = static::getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager       = $container->get(EntityManagerInterface::class);
+        $this->entityManager = $entityManager;
+
+        /** @var AccountDomainService $accountDomainService */
+        $accountDomainService       = $container->get(AccountDomainService::class);
+        $this->accountDomainService = $accountDomainService;
+
+        /** @var AccountFacadeInterface $accountFacade */
+        $accountFacade       = $container->get(AccountFacadeInterface::class);
+        $this->accountFacade = $accountFacade;
+    }
+
+    public function testProjectListShowsCloneAction(): void
+    {
+        $user           = $this->createTestUser('clone-list-' . uniqid() . '@example.com', 'password123');
+        $organizationId = $this->getOrganizationIdForUser($user);
+        $project        = $this->createBasicProject($organizationId, 'Project To Clone');
+
+        $projectId = $project->getId();
+        self::assertNotNull($projectId);
+
+        $this->loginAsUser($this->client, $user);
+        $crawler = $this->client->request('GET', '/en/projects');
+
+        self::assertResponseIsSuccessful();
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('a[href="/en/projects/' . $projectId . '/clone"][data-test-class="project-list-clone-link"]')->count()
+        );
+    }
+
+    public function testCloneFormShowsSuggestedNameForSourceProject(): void
+    {
+        $user           = $this->createTestUser('clone-form-' . uniqid() . '@example.com', 'password123');
+        $organizationId = $this->getOrganizationIdForUser($user);
+        $project        = $this->createBasicProject($organizationId, 'Source Website');
+
+        $projectId = $project->getId();
+        self::assertNotNull($projectId);
+
+        $this->loginAsUser($this->client, $user);
+        $crawler = $this->client->request('GET', '/en/projects/' . $projectId . '/clone');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-test-id="project-clone-form"]');
+        self::assertSame('Copy of Source Website', $crawler->filter('[data-test-id="project-clone-name"]')->attr('value'));
+    }
+
+    public function testCloneCopiesProjectSettingsAndDoesNotCopyWorkspace(): void
+    {
+        $user           = $this->createTestUser('clone-happy-' . uniqid() . '@example.com', 'password123');
+        $organizationId = $this->getOrganizationIdForUser($user);
+        $sourceProject  = $this->createConfiguredProject($organizationId, 'Configured Source Project');
+
+        $sourceProjectId = $sourceProject->getId();
+        self::assertNotNull($sourceProjectId);
+
+        $sourceWorkspace = new Workspace($sourceProjectId);
+        $sourceWorkspace->setStatus(WorkspaceStatus::IN_REVIEW);
+        $sourceWorkspace->setBranchName('feature/original-work');
+        $sourceWorkspace->setPullRequestUrl('https://github.com/org/repo/pull/123');
+        $this->entityManager->persist($sourceWorkspace);
+        $this->entityManager->flush();
+
+        $this->loginAsUser($this->client, $user);
+        $crawler = $this->client->request('GET', '/en/projects/' . $sourceProjectId . '/clone');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('[data-test-id="project-clone-form"]')->form([
+            'name' => 'Cloned Project',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/en/projects');
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('body', 'cloned successfully');
+
+        $this->entityManager->clear();
+
+        /** @var Project|null $clonedProject */
+        $clonedProject = $this->entityManager->getRepository(Project::class)->findOneBy([
+            'organizationId' => $organizationId,
+            'name'           => 'Cloned Project',
+        ]);
+
+        self::assertNotNull($clonedProject);
+        self::assertNotSame($sourceProjectId, $clonedProject->getId());
+        self::assertSame($organizationId, $clonedProject->getOrganizationId());
+        self::assertSame($sourceProject->getGitUrl(), $clonedProject->getGitUrl());
+        self::assertSame($sourceProject->getGithubToken(), $clonedProject->getGithubToken());
+        self::assertSame($sourceProject->getContentEditingLlmModelProvider(), $clonedProject->getContentEditingLlmModelProvider());
+        self::assertSame($sourceProject->getContentEditingLlmModelProviderApiKey(), $clonedProject->getContentEditingLlmModelProviderApiKey());
+        self::assertSame($sourceProject->getAgentImage(), $clonedProject->getAgentImage());
+        self::assertSame($sourceProject->getAgentBackgroundInstructions(), $clonedProject->getAgentBackgroundInstructions());
+        self::assertSame($sourceProject->getAgentStepInstructions(), $clonedProject->getAgentStepInstructions());
+        self::assertSame($sourceProject->getAgentOutputInstructions(), $clonedProject->getAgentOutputInstructions());
+        self::assertSame($sourceProject->getRemoteContentAssetsManifestUrls(), $clonedProject->getRemoteContentAssetsManifestUrls());
+        self::assertSame($sourceProject->getS3BucketName(), $clonedProject->getS3BucketName());
+        self::assertSame($sourceProject->getS3Region(), $clonedProject->getS3Region());
+        self::assertSame($sourceProject->getS3AccessKeyId(), $clonedProject->getS3AccessKeyId());
+        self::assertSame($sourceProject->getS3SecretAccessKey(), $clonedProject->getS3SecretAccessKey());
+        self::assertSame($sourceProject->getS3IamRoleArn(), $clonedProject->getS3IamRoleArn());
+        self::assertSame($sourceProject->getS3KeyPrefix(), $clonedProject->getS3KeyPrefix());
+        self::assertSame($sourceProject->isKeysVisible(), $clonedProject->isKeysVisible());
+        self::assertSame($sourceProject->getPhotoBuilderLlmModelProvider(), $clonedProject->getPhotoBuilderLlmModelProvider());
+        self::assertSame($sourceProject->getPhotoBuilderLlmModelProviderApiKey(), $clonedProject->getPhotoBuilderLlmModelProviderApiKey());
+        self::assertFalse($clonedProject->isDeleted());
+
+        $clonedProjectId = $clonedProject->getId();
+        self::assertNotNull($clonedProjectId);
+        self::assertNull(
+            $this->entityManager->getRepository(Workspace::class)->findOneBy(['projectId' => $clonedProjectId])
+        );
+    }
+
+    public function testCloneReturnsNotFoundForProjectFromAnotherOrganization(): void
+    {
+        $ownerUser           = $this->createTestUser('clone-owner-' . uniqid() . '@example.com', 'password123');
+        $ownerOrganizationId = $this->getOrganizationIdForUser($ownerUser);
+        $sourceProject       = $this->createBasicProject($ownerOrganizationId, 'Owner Project');
+
+        $otherUser = $this->createTestUser('clone-other-' . uniqid() . '@example.com', 'password123');
+        $this->loginAsUser($this->client, $otherUser);
+
+        $projectId = $sourceProject->getId();
+        self::assertNotNull($projectId);
+
+        $this->client->request('GET', '/en/projects/' . $projectId . '/clone');
+        self::assertResponseStatusCodeSame(404);
+
+        $this->client->request('POST', '/en/projects/' . $projectId . '/clone', [
+            '_csrf_token' => 'dummy-token',
+            'name'        => 'Cross Org Clone',
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testCloneReturnsNotFoundForDeletedSourceProject(): void
+    {
+        $user           = $this->createTestUser('clone-deleted-' . uniqid() . '@example.com', 'password123');
+        $organizationId = $this->getOrganizationIdForUser($user);
+        $sourceProject  = $this->createBasicProject($organizationId, 'Deleted Source');
+        $sourceProject->markAsDeleted();
+        $this->entityManager->flush();
+
+        $projectId = $sourceProject->getId();
+        self::assertNotNull($projectId);
+
+        $this->loginAsUser($this->client, $user);
+        $this->client->request('GET', '/en/projects/' . $projectId . '/clone');
+        self::assertResponseStatusCodeSame(404);
+
+        $this->client->request('POST', '/en/projects/' . $projectId . '/clone', [
+            '_csrf_token' => 'dummy-token',
+            'name'        => 'Clone Attempt',
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testCloneWithEmptyNameShowsValidationAndDoesNotCreateProject(): void
+    {
+        $user           = $this->createTestUser('clone-empty-name-' . uniqid() . '@example.com', 'password123');
+        $organizationId = $this->getOrganizationIdForUser($user);
+        $sourceProject  = $this->createBasicProject($organizationId, 'Source Name Validation');
+
+        $projectId = $sourceProject->getId();
+        self::assertNotNull($projectId);
+
+        $this->loginAsUser($this->client, $user);
+        $crawler = $this->client->request('GET', '/en/projects/' . $projectId . '/clone');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('[data-test-id="project-clone-form"]')->form([
+            'name' => '   ',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/en/projects/' . $projectId . '/clone');
+        $this->client->followRedirect();
+        self::assertSelectorTextContains('body', 'Please enter a name for the cloned project.');
+
+        $this->entityManager->clear();
+        self::assertNull($this->entityManager->getRepository(Project::class)->findOneBy([
+            'organizationId' => $organizationId,
+            'name'           => '   ',
+        ]));
+    }
+
+    private function createTestUser(string $email, string $plainPassword): AccountCore
+    {
+        return $this->accountDomainService->register($email, $plainPassword);
+    }
+
+    private function getOrganizationIdForUser(AccountCore $user): string
+    {
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $organizationId = $this->accountFacade->getCurrentlyActiveOrganizationIdForAccountCore($userId);
+        self::assertNotNull($organizationId, 'User should have an organization after registration');
+
+        return $organizationId;
+    }
+
+    private function createBasicProject(string $organizationId, string $name): Project
+    {
+        $project = new Project(
+            $organizationId,
+            $name,
+            'https://github.com/test/repo.git',
+            'ghp_testtoken123',
+            LlmModelProvider::OpenAI,
+            'sk-test-key-123'
+        );
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createConfiguredProject(string $organizationId, string $name): Project
+    {
+        $project = new Project(
+            $organizationId,
+            $name,
+            'https://github.com/source/repository.git',
+            'ghp_source_token',
+            LlmModelProvider::OpenAI,
+            'sk-source-api-key',
+            ProjectType::DEFAULT,
+            'python:3.12-slim',
+            'Background instructions',
+            'Step instructions',
+            'Output instructions',
+            ['https://cdn.example.com/manifest.json']
+        );
+        $project->setS3BucketName('source-bucket');
+        $project->setS3Region('eu-central-1');
+        $project->setS3AccessKeyId('AKIA_SOURCE');
+        $project->setS3SecretAccessKey('source-secret');
+        $project->setS3IamRoleArn('arn:aws:iam::123456789012:role/SourceRole');
+        $project->setS3KeyPrefix('assets/source');
+        $project->setKeysVisible(false);
+        $project->setPhotoBuilderLlmModelProvider(LlmModelProvider::OpenAI);
+        $project->setPhotoBuilderLlmModelProviderApiKey('sk-photo-builder');
+
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+}

--- a/tests/Unit/ProjectMgmt/ProjectServiceTest.php
+++ b/tests/Unit/ProjectMgmt/ProjectServiceTest.php
@@ -63,6 +63,61 @@ final class ProjectServiceTest extends TestCase
         self::assertSame($manifestUrls, $project->getRemoteContentAssetsManifestUrls());
     }
 
+    public function testCloneProjectCopiesConfigurationWithoutCopyingIdentityFields(): void
+    {
+        $sourceProject = $this->createProject(
+            'source-project-id',
+            'Source Project',
+            'https://github.com/org/source.git',
+            'gh-source-token'
+        );
+        $sourceProject->setAgentImage('python:3.12-slim');
+        $sourceProject->setAgentBackgroundInstructions('Background instructions');
+        $sourceProject->setAgentStepInstructions('Step instructions');
+        $sourceProject->setAgentOutputInstructions('Output instructions');
+        $sourceProject->setRemoteContentAssetsManifestUrls(['https://cdn.example.com/manifest.json']);
+        $sourceProject->setS3BucketName('bucket-name');
+        $sourceProject->setS3Region('eu-central-1');
+        $sourceProject->setS3AccessKeyId('AKIAEXAMPLE');
+        $sourceProject->setS3SecretAccessKey('secret-example');
+        $sourceProject->setS3IamRoleArn('arn:aws:iam::123456789012:role/SiteBuilder');
+        $sourceProject->setS3KeyPrefix('uploads/project');
+        $sourceProject->setKeysVisible(false);
+        $sourceProject->setPhotoBuilderLlmModelProvider(LlmModelProvider::OpenAI);
+        $sourceProject->setPhotoBuilderLlmModelProviderApiKey('photo-builder-key');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $service       = new ProjectService($entityManager);
+        $clonedProject = $service->cloneProject($sourceProject, 'Cloned Project');
+
+        self::assertNotSame($sourceProject, $clonedProject);
+        self::assertSame('org-123', $clonedProject->getOrganizationId());
+        self::assertSame('Cloned Project', $clonedProject->getName());
+        self::assertSame($sourceProject->getGitUrl(), $clonedProject->getGitUrl());
+        self::assertSame($sourceProject->getGithubToken(), $clonedProject->getGithubToken());
+        self::assertSame($sourceProject->getContentEditingLlmModelProvider(), $clonedProject->getContentEditingLlmModelProvider());
+        self::assertSame($sourceProject->getContentEditingLlmModelProviderApiKey(), $clonedProject->getContentEditingLlmModelProviderApiKey());
+        self::assertSame($sourceProject->getAgentImage(), $clonedProject->getAgentImage());
+        self::assertSame($sourceProject->getAgentBackgroundInstructions(), $clonedProject->getAgentBackgroundInstructions());
+        self::assertSame($sourceProject->getAgentStepInstructions(), $clonedProject->getAgentStepInstructions());
+        self::assertSame($sourceProject->getAgentOutputInstructions(), $clonedProject->getAgentOutputInstructions());
+        self::assertSame($sourceProject->getRemoteContentAssetsManifestUrls(), $clonedProject->getRemoteContentAssetsManifestUrls());
+        self::assertSame($sourceProject->getS3BucketName(), $clonedProject->getS3BucketName());
+        self::assertSame($sourceProject->getS3Region(), $clonedProject->getS3Region());
+        self::assertSame($sourceProject->getS3AccessKeyId(), $clonedProject->getS3AccessKeyId());
+        self::assertSame($sourceProject->getS3SecretAccessKey(), $clonedProject->getS3SecretAccessKey());
+        self::assertSame($sourceProject->getS3IamRoleArn(), $clonedProject->getS3IamRoleArn());
+        self::assertSame($sourceProject->getS3KeyPrefix(), $clonedProject->getS3KeyPrefix());
+        self::assertSame($sourceProject->isKeysVisible(), $clonedProject->isKeysVisible());
+        self::assertSame($sourceProject->getPhotoBuilderLlmModelProvider(), $clonedProject->getPhotoBuilderLlmModelProvider());
+        self::assertSame($sourceProject->getPhotoBuilderLlmModelProviderApiKey(), $clonedProject->getPhotoBuilderLlmModelProviderApiKey());
+        self::assertNull($clonedProject->getId());
+        self::assertFalse($clonedProject->isDeleted());
+    }
+
     public function testUpdateUpdatesAllProjectAttributes(): void
     {
         $project = $this->createProject('proj-1', 'Old Name', 'https://old.git', 'old-token');

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -77,6 +77,7 @@ project:
         view_conversation: "Konversation ansehen"
         view_conversation_for_review: "Konversation wg. Review ansehen"
         edit_details: "Details bearbeiten"
+        clone_project: "Projekt klonen"
         reset_work_area: "Arbeitsbereich zurücksetzen"
         reset_confirm: "Arbeitsbereich zurücksetzen? Dies beendet alle aktiven Sitzungen und erstellt beim nächsten Mal einen neuen Arbeitsbereich."
         delete_confirm: "Dieses Projekt löschen? Es wird aus der Liste entfernt."
@@ -86,6 +87,15 @@ project:
         restore: "Wiederherstellen"
         delete_permanently: "Endgültig löschen"
         delete_permanently_confirm: "Dieses Projekt endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden und entfernt alle zugehörigen Daten."
+    clone:
+        title: "Projekt klonen"
+        heading: "Projekt klonen"
+        description: 'Erstellen Sie ein neues Projekt, indem Sie alle Einstellungen von "%name%" übernehmen.'
+        default_name: "Kopie von %name%"
+        project_name: "Neuer Projektname"
+        project_name_placeholder: "Kopie von Meine Website"
+        source_project: "Quellprojekt:"
+        submit: "Projekt klonen"
     form:
         title_add: "Projekt hinzufügen"
         title_edit: "Projekt bearbeiten"
@@ -377,6 +387,7 @@ flash:
     error:
         invalid_csrf: "Ungültiges CSRF-Token."
         all_fields_required: "Alle Felder sind erforderlich."
+        project_clone_name_required: "Bitte geben Sie einen Namen für das geklonte Projekt ein."
         select_llm_provider: "Bitte wählen Sie einen LLM-Modellanbieter."
         invalid_docker_image: "Ungültiges Docker-Image-Format. Erwartetes Format: name:tag"
         no_workspace: "Für dieses Projekt existiert kein Arbeitsbereich."
@@ -393,6 +404,7 @@ flash:
         workspace_busy: "%email% arbeitet gerade an diesem Arbeitsbereich."
     success:
         project_created: "Projekt erfolgreich erstellt."
+        project_cloned: 'Projekt "%name%" erfolgreich geklont.'
         project_updated: "Projekt erfolgreich aktualisiert."
         project_deleted: 'Projekt "%name%" erfolgreich gelöscht.'
         project_permanently_deleted: 'Projekt "%name%" endgültig gelöscht.'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -77,6 +77,7 @@ project:
         view_conversation: "View conversation"
         view_conversation_for_review: "Review conversation"
         edit_details: "Edit details"
+        clone_project: "Clone project"
         reset_work_area: "Reset work area"
         reset_confirm: "Reset this work area? This will end any active sessions and create a fresh work area next time."
         delete_confirm: "Delete this project? It will be removed from the list."
@@ -86,6 +87,15 @@ project:
         restore: "Restore"
         delete_permanently: "Delete permanently"
         delete_permanently_confirm: "Permanently delete this project? This action cannot be undone and will remove all associated data."
+    clone:
+        title: "Clone project"
+        heading: "Clone project"
+        description: 'Create a new project by copying all settings from "%name%".'
+        default_name: "Copy of %name%"
+        project_name: "New project name"
+        project_name_placeholder: "Copy of My Website"
+        source_project: "Source project:"
+        submit: "Clone project"
     form:
         title_add: "Add project"
         title_edit: "Edit project"
@@ -377,6 +387,7 @@ flash:
     error:
         invalid_csrf: "Invalid CSRF token."
         all_fields_required: "All fields are required."
+        project_clone_name_required: "Please enter a name for the cloned project."
         select_llm_provider: "Please select an LLM model provider."
         invalid_docker_image: "Invalid Docker image format. Expected format: name:tag"
         no_workspace: "No workspace exists for this project."
@@ -393,6 +404,7 @@ flash:
         workspace_busy: "%email% is currently working on this workspace."
     success:
         project_created: "Project created successfully."
+        project_cloned: 'Project "%name%" cloned successfully.'
         project_updated: "Project updated successfully."
         project_deleted: 'Project "%name%" deleted successfully.'
         project_permanently_deleted: 'Project "%name%" permanently deleted.'


### PR DESCRIPTION
Add project cloning functionality to allow users to duplicate existing projects.

This PR introduces a new `/projects/{id}/clone` route (GET/POST) to handle project duplication. It includes `ProjectService::cloneProject()` for copying project settings, a dedicated clone form, and a "Clone project" action in the project list UI, along with corresponding EN/DE translations. Comprehensive unit and integration tests cover happy paths, access control, and validation. A minor fix was also included to address a TypeScript compatibility issue in `remote_asset_browser_controller.ts`.

Closes #161.

---
<p><a href="https://cursor.com/agents/bc-220ab45b-a40b-4edf-9eee-cdc354e78a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-220ab45b-a40b-4edf-9eee-cdc354e78a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

